### PR TITLE
Strip hitbox polygons from PubSub broadcasts

### DIFF
--- a/lib/flappy/flappy_engine.ex
+++ b/lib/flappy/flappy_engine.ex
@@ -160,7 +160,7 @@ defmodule Flappy.FlappyEngine do
         calculate_score_and_update_view(state)
 
       {:ok, state} ->
-        Phoenix.PubSub.broadcast(Flappy.PubSub, "flappy:game_state:#{game_id}", {:game_state_update, state})
+        Phoenix.PubSub.broadcast(Flappy.PubSub, "flappy:game_state:#{game_id}", {:game_state_update, strip_hitboxes(state)})
         {:noreply, state}
     end
   end
@@ -176,12 +176,22 @@ defmodule Flappy.FlappyEngine do
     Players.update_player(player, %{score: player.score})
     high_score? = Enum.any?(current_high_scores, fn {_name, score} -> player.score > score end)
 
-    if high_score?,
-      do: Phoenix.PubSub.broadcast(Flappy.PubSub, "flappy:game_state:global", {:high_score, state}),
-      else: Phoenix.PubSub.broadcast(Flappy.PubSub, "flappy:game_state:global", {:new_score, state})
+    broadcast_state = strip_hitboxes(state)
 
-    Phoenix.PubSub.broadcast(Flappy.PubSub, "flappy:game_state:#{game_id}", {:game_state_update, state})
+    if high_score?,
+      do: Phoenix.PubSub.broadcast(Flappy.PubSub, "flappy:game_state:global", {:high_score, broadcast_state}),
+      else: Phoenix.PubSub.broadcast(Flappy.PubSub, "flappy:game_state:global", {:new_score, broadcast_state})
+
+    Phoenix.PubSub.broadcast(Flappy.PubSub, "flappy:game_state:#{game_id}", {:game_state_update, broadcast_state})
     {:noreply, state}
+  end
+
+  defp strip_hitboxes(state) do
+    %{state |
+      enemies: Enum.map(state.enemies, &%{&1 | hitbox: nil}),
+      power_ups: Enum.map(state.power_ups, &%{&1 | hitbox: nil}),
+      player: Map.put(state.player, :hitbox, nil)
+    }
   end
 
   ### PUBLIC API


### PR DESCRIPTION
## Summary
- Cached `Polygons.Polygon` structs are only needed server-side for collision detection
- Broadcasting them to the LiveView every 15ms (with up to 300 enemies) adds unnecessary serialization overhead
- Adds `strip_hitboxes/1` helper that nils out hitbox fields before all PubSub broadcasts
- GenServer retains the cached hitboxes in its own state for the next tick

## Test plan
- [x] All 32 existing tests pass
- [x] Clean compilation with `--warnings-as-errors`
- [ ] Manual playtest to verify rendering unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)