### PR TITLE
Fix laser hitbox bug and add collision detection tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,13 @@
 import Config
 
+# Configure the test database
+config :flappy, Flappy.Repo,
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  database: "flappy_repo_test",
+  pool: Ecto.Adapters.SQL.Sandbox
+
 # In test we don't send emails
 config :flappy, Flappy.Mailer, adapter: Swoosh.Adapters.Test
 

--- a/lib/flappy/hitbox.ex
+++ b/lib/flappy/hitbox.ex
@@ -82,7 +82,7 @@ defmodule Flappy.Hitbox do
       {x, y},
       {x + w, y},
       {x + w, y + h},
-      {w, y + h}
+      {x, y + h}
     ])
   end
 

--- a/test/flappy/hitbox_test.exs
+++ b/test/flappy/hitbox_test.exs
@@ -65,6 +65,73 @@ defmodule Flappy.HitboxTest do
     end
   end
 
+  describe "get_hit_enemies/2 laser" do
+    test "laser hits enemy in its path" do
+      # Player at x=12.5%, y=50% on 800×600
+      game_state = %{
+        game_width: 800,
+        game_height: 600,
+        player: %{
+          sprite: %{size: {50, 50}},
+          position: {100.0, 300.0, 12.5, 50.0}
+        }
+      }
+
+      # Enemy placed ahead of the laser beam at ~30% x, same y height
+      enemy = %{
+        position: {240.0, 300.0, 30.0, 50.0},
+        sprite: %{size: {100, 100}, name: :angular}
+      }
+
+      result = Hitbox.get_hit_enemies([enemy], game_state)
+      assert length(result) > 0
+    end
+
+    test "laser does not hit enemy far above the beam" do
+      game_state = %{
+        game_width: 800,
+        game_height: 600,
+        player: %{
+          sprite: %{size: {50, 50}},
+          position: {100.0, 300.0, 12.5, 50.0}
+        }
+      }
+
+      # Enemy far above the laser beam
+      enemy = %{
+        position: {240.0, 30.0, 30.0, 5.0},
+        sprite: %{size: {100, 100}, name: :angular}
+      }
+
+      result = Hitbox.get_hit_enemies([enemy], game_state)
+      assert result == []
+    end
+
+    test "laser hitbox is a proper rectangle (not a trapezoid)" do
+      # Regression: previously the bottom-left vertex used {w, y+h}
+      # instead of {x, y+h}, creating a trapezoid
+      game_state = %{
+        game_width: 800,
+        game_height: 600,
+        player: %{
+          sprite: %{size: {50, 50}},
+          position: {400.0, 300.0, 50.0, 50.0}
+        }
+      }
+
+      # Enemy behind the player (x=5%) should NOT be hit by a laser
+      # that starts at the bird's eye (~x=55%). With the old bug,
+      # the trapezoid stretched back to x=100px and could false-positive.
+      enemy = %{
+        position: {40.0, 300.0, 5.0, 50.0},
+        sprite: %{size: {100, 100}, name: :angular}
+      }
+
+      result = Hitbox.get_hit_enemies([enemy], game_state)
+      assert result == [], "laser should not hit enemies behind the player"
+    end
+  end
+
   describe "check_for_enemy_collisions?/1" do
     test "detects player collision with enemy" do
       state = %{

--- a/test/polygons/detection_test.exs
+++ b/test/polygons/detection_test.exs
@@ -1,0 +1,263 @@
+defmodule Polygons.DetectionTest do
+  use ExUnit.Case, async: true
+
+  alias Polygons.Detection
+  alias Polygons.Polygon
+
+  # -- helpers ---------------------------------------------------------------
+
+  defp square(x, y, size) do
+    Polygon.make([{x, y}, {x + size, y}, {x + size, y + size}, {x, y + size}])
+  end
+
+  defp triangle(x, y, base, height) do
+    Polygon.make([{x, y + height}, {x + base / 2, y}, {x + base, y + height}])
+  end
+
+  # -- Polygon.make & coerce_floats -----------------------------------------
+
+  describe "Polygon.make/1" do
+    test "coerces integer vertices to floats" do
+      poly = Polygon.make([{1, 2}, {3, 4}])
+      assert poly.vertices == [{1.0, 2.0}, {3.0, 4.0}]
+    end
+
+    test "preserves float vertices" do
+      poly = Polygon.make([{1.5, 2.5}])
+      assert poly.vertices == [{1.5, 2.5}]
+    end
+  end
+
+  # -- Polygon.center -------------------------------------------------------
+
+  describe "Polygon.center/1" do
+    test "centroid of a unit square at origin" do
+      poly = square(0, 0, 2)
+      {cx, cy} = Polygon.center(poly)
+      assert_in_delta cx, 1.0, 0.01
+      assert_in_delta cy, 1.0, 0.01
+    end
+
+    test "centroid of a translated square" do
+      poly = square(10, 20, 4)
+      {cx, cy} = Polygon.center(poly)
+      assert_in_delta cx, 12.0, 0.01
+      assert_in_delta cy, 22.0, 0.01
+    end
+  end
+
+  # -- overlap? -------------------------------------------------------------
+
+  describe "overlap?/2" do
+    test "touching ranges overlap" do
+      assert Detection.overlap?({0.0, 5.0}, {5.0, 10.0})
+    end
+
+    test "contained range overlaps" do
+      assert Detection.overlap?({-1.0, -3.0}, {-6.1, 3.5})
+    end
+
+    test "disjoint ranges do not overlap" do
+      refute Detection.overlap?({-1.0, 0.0}, {0.01, 1.0})
+    end
+
+    test "identical ranges overlap" do
+      assert Detection.overlap?({2.0, 5.0}, {2.0, 5.0})
+    end
+
+    test "list form delegates correctly" do
+      assert Detection.overlap?([{0.0, 3.0}, {2.0, 5.0}])
+      refute Detection.overlap?([{0.0, 1.0}, {2.0, 3.0}])
+    end
+  end
+
+  # -- normals_of_edges ------------------------------------------------------
+
+  describe "normals_of_edges/1" do
+    test "returns one normal per edge" do
+      poly = square(0, 0, 1)
+      normals = Detection.normals_of_edges(poly)
+      assert length(normals) == 4
+    end
+
+    test "normals are perpendicular to edges" do
+      poly = Polygon.make([{0, 0}, {1, 0}, {1, 1}, {0, 1}])
+      normals = Detection.normals_of_edges(poly)
+
+      # Each normal dotted with its edge should be zero
+      edges =
+        poly.vertices
+        |> Enum.chunk_every(2, 1, [hd(poly.vertices)])
+        |> Enum.map(fn [{x1, y1}, {x2, y2}] -> {x2 - x1, y2 - y1} end)
+
+      Enum.zip(normals, edges)
+      |> Enum.each(fn {{nx, ny}, {ex, ey}} ->
+        dot = nx * ex + ny * ey
+        assert_in_delta dot, 0.0, 1.0e-10, "normal should be perpendicular to edge"
+      end)
+    end
+  end
+
+  # -- collision? :accurate --------------------------------------------------
+
+  describe "collision?/3 :accurate" do
+    test "identical squares collide" do
+      sq = square(0, 0, 10)
+      assert Detection.collision?(sq, sq, :accurate)
+    end
+
+    test "overlapping squares collide" do
+      assert Detection.collision?(square(0, 0, 10), square(5, 5, 10), :accurate)
+    end
+
+    test "adjacent (touching) squares collide" do
+      # Edge-to-edge: overlap? counts touching as overlapping
+      assert Detection.collision?(square(0, 0, 10), square(10, 0, 10), :accurate)
+    end
+
+    test "separated squares do not collide" do
+      refute Detection.collision?(square(0, 0, 10), square(20, 0, 10), :accurate)
+    end
+
+    test "one square fully inside another" do
+      big = square(0, 0, 100)
+      small = square(40, 40, 5)
+      assert Detection.collision?(big, small, :accurate)
+    end
+
+    test "separated along Y axis only" do
+      refute Detection.collision?(square(0, 0, 5), square(0, 10, 5), :accurate)
+    end
+
+    test "near-miss with gap" do
+      refute Detection.collision?(square(0, 0, 5), square(5.01, 0, 5), :accurate)
+    end
+
+    test "triangles overlapping" do
+      t1 = triangle(0, 0, 10, 10)
+      t2 = triangle(5, 0, 10, 10)
+      assert Detection.collision?(t1, t2, :accurate)
+    end
+
+    test "triangles separated" do
+      t1 = triangle(0, 0, 5, 5)
+      t2 = triangle(20, 0, 5, 5)
+      refute Detection.collision?(t1, t2, :accurate)
+    end
+
+    test "triangle and square overlapping" do
+      t = triangle(0, 0, 10, 10)
+      s = square(3, 3, 5)
+      assert Detection.collision?(t, s, :accurate)
+    end
+
+    test "default method is :accurate" do
+      refute Detection.collision?(square(0, 0, 5), square(20, 0, 5))
+      assert Detection.collision?(square(0, 0, 10), square(5, 5, 10))
+    end
+  end
+
+  # -- collision? :fast ------------------------------------------------------
+
+  describe "collision?/3 :fast" do
+    test "clearly overlapping squares detected" do
+      assert Detection.collision?(square(0, 0, 10), square(5, 5, 10), :fast)
+    end
+
+    test "clearly separated squares not detected" do
+      refute Detection.collision?(square(0, 0, 5), square(50, 50, 5), :fast)
+    end
+
+    test "identical polygons detected" do
+      sq = square(0, 0, 10)
+      assert Detection.collision?(sq, sq, :fast)
+    end
+  end
+
+  # -- game-realistic scenarios ----------------------------------------------
+
+  describe "game-realistic hitbox scenarios" do
+    test "player-shaped polygon collides with enemy-shaped polygon at same position" do
+      # Simulate player hitbox at (10, 10) on an 800×600 game
+      player = Polygons.Polygon.make([
+        {10.0, 13.0},
+        {11.25, 11.5},
+        {15.0, 10.0},
+        {16.25, 10.5},
+        {15.0, 13.0},
+        {11.875, 15.0}
+      ])
+
+      # Enemy diamond at same area
+      enemy = Polygons.Polygon.make([
+        {10.625, 11.66},
+        {16.25, 10.0},
+        {22.5, 11.66},
+        {21.375, 14.66},
+        {16.25, 16.66},
+        {10.625, 14.66}
+      ])
+
+      assert Detection.collision?(player, enemy, :accurate)
+    end
+
+    test "player and far-away enemy do not collide" do
+      player = Polygons.Polygon.make([
+        {10.0, 13.0},
+        {11.25, 11.5},
+        {15.0, 10.0},
+        {16.25, 10.5},
+        {15.0, 13.0},
+        {11.875, 15.0}
+      ])
+
+      enemy = Polygons.Polygon.make([
+        {80.0, 80.0},
+        {85.0, 78.0},
+        {90.0, 80.0},
+        {89.0, 84.0},
+        {85.0, 86.0},
+        {81.0, 84.0}
+      ])
+
+      refute Detection.collision?(player, enemy, :accurate)
+      refute Detection.collision?(player, enemy, :fast)
+    end
+
+    test "laser beam (thin rectangle) intersects enemy" do
+      laser = Polygons.Polygon.make([
+        {15.0, 50.0},
+        {100.0, 50.0},
+        {100.0, 50.1},
+        {15.0, 50.1}
+      ])
+
+      enemy = Polygons.Polygon.make([
+        {50.0, 45.0},
+        {60.0, 45.0},
+        {60.0, 55.0},
+        {50.0, 55.0}
+      ])
+
+      assert Detection.collision?(laser, enemy, :accurate)
+    end
+
+    test "laser beam misses enemy above it" do
+      laser = Polygons.Polygon.make([
+        {15.0, 50.0},
+        {100.0, 50.0},
+        {100.0, 50.1},
+        {15.0, 50.1}
+      ])
+
+      enemy = Polygons.Polygon.make([
+        {50.0, 30.0},
+        {60.0, 30.0},
+        {60.0, 40.0},
+        {50.0, 40.0}
+      ])
+
+      refute Detection.collision?(laser, enemy, :accurate)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
 ExUnit.start()
+Ecto.Adapters.SQL.Sandbox.mode(Flappy.Repo, :manual)


### PR DESCRIPTION
## Summary
- **Fix:** Laser hitbox vertex used `{w, y+h}` instead of `{x, y+h}`, creating a trapezoid that could false-positive on enemies behind the player
- **Tests:** Add 29 tests for `Polygons.Detection` (SAT algorithm, overlap, normals, game-realistic scenarios) and 3 laser collision tests including a regression test for the bug
- **Config:** Add test database config and Ecto sandbox setup

## Test plan
- [x] All 88 tests pass
- [x] Regression test confirms laser no longer hits enemies behind the player
- [x] SAT algorithm tested for edge cases: near-miss, touching edges, containment, mixed shapes, thin rectangles (laser beams)

🤖 Generated with [Claude Code](https://claude.com/claude-code)