### PR TITLE
Multiplayer: King of the Hill

### DIFF
--- a/lib/flappy/application.ex
+++ b/lib/flappy/application.ex
@@ -14,8 +14,8 @@ defmodule Flappy.Application do
       {Phoenix.PubSub, name: Flappy.PubSub},
       # Start the Finch HTTP client for sending emails
       {Finch, name: Flappy.Finch},
-      # Start a worker by calling: Flappy.Worker.start_link(arg)
-      # {Flappy.Worker, arg},
+      # Global multiplayer engine
+      Flappy.MultiplayerEngine,
       # Start to serve requests, typically the last entry
       FlappyWeb.Endpoint
     ]

--- a/lib/flappy/enemy.ex
+++ b/lib/flappy/enemy.ex
@@ -19,7 +19,8 @@ defmodule Flappy.Enemy do
     %{image: "/images/node.svg", size: {100, 100}, name: :node}
   ]
 
-  def maybe_generate_enemy(%{enemies: enemies, player: %{score: score}} = state) do
+  def maybe_generate_enemy(%{enemies: enemies} = state) do
+    score = effective_score(state)
     # The game gets harder as the score increases
     difficultly_rating = if score < state.difficulty_score - 5, do: score, else: state.difficulty_score - 4
     difficultly_cap = state.difficulty_score - difficultly_rating
@@ -75,17 +76,25 @@ defmodule Flappy.Enemy do
     %{state | enemies: enemies}
   end
 
-  def remove_hit_enemies(%{player: player} = state, enemies_hit) do
+  def remove_hit_enemies(state, enemies_hit, player_id) do
     hit_ids = MapSet.new(enemies_hit, & &1.id)
 
     {enemies, new_explosions} =
       Enum.reduce(state.enemies, {[], []}, fn enemy, {remaining, explosions} ->
         if MapSet.member?(hit_ids, enemy.id) do
+          {enemy_w, enemy_h} = enemy.sprite.size
+          {ex, ey, exp, eyp} = enemy.position
+
+          # Center the explosion on the enemy
+          explosion_size = 100
+          x_offset = (enemy_w - explosion_size) / 2 / state.game_width * 100
+          y_offset = (enemy_h - explosion_size) / 2 / state.game_height * 100
+
           explosion = %Explosion{
             duration: 3,
-            position: enemy.position,
-            velocity: enemy.velocity,
-            sprite: %{image: "/images/explosion.svg", size: {100, 100}, name: :explosion},
+            position: {ex, ey, exp + x_offset, eyp + y_offset},
+            velocity: {0, 0},
+            sprite: %{image: "/images/explosion.svg", size: {explosion_size, explosion_size}, name: :explosion},
             id: Ecto.UUID.generate()
           }
 
@@ -95,9 +104,18 @@ defmodule Flappy.Enemy do
         end
       end)
 
+    player = state.players[player_id]
     updated_score = player.score + PowerUp.score_for_kills(length(new_explosions), state.score_multiplier)
     player = %{player | score: updated_score}
 
-    %{state | enemies: enemies, explosions: new_explosions ++ state.explosions, player: player}
+    %{state | enemies: enemies, explosions: new_explosions ++ state.explosions, players: Map.put(state.players, player_id, player)}
+  end
+
+  defp effective_score(%{players: players}) do
+    players
+    |> Map.values()
+    |> Enum.filter(&Map.get(&1, :alive, true))
+    |> Enum.map(& &1.score)
+    |> Enum.max(fn -> 0 end)
   end
 end

--- a/lib/flappy/flappy_engine.ex
+++ b/lib/flappy/flappy_engine.ex
@@ -19,83 +19,97 @@ defmodule Flappy.FlappyEngine do
         player_name: player_name,
         zoom_level: zoom_level
       }) do
-    player = Players.create_player!(%{name: player_name, score: @start_score, version: get_game_version()})
+    player_id = Ecto.UUID.generate()
+    db_player = Players.create_player!(%{name: player_name, score: @start_score, version: get_game_version()})
     current_game_version = Application.get_env(:flappy, :game_version, "1")
     current_high_scores = Players.get_current_high_scores(5, current_game_version)
 
-    state =
+    game_state =
       GameState.new(
         game_id: game_id,
+        player_id: player_id,
         game_height: game_height,
         game_width: game_width,
         zoom_level: zoom_level,
         gravity: 175 / zoom_level,
         current_high_scores: current_high_scores,
         player: %{
-          Map.from_struct(player)
-          | position: {100, game_height / 2, 10, 50},
-            velocity: {0, 0},
-            sprite: Players.get_sprite(),
-            granted_powers: [],
-            laser_allowed: false,
-            laser_beam: false,
-            laser_duration: 0,
-            invincibility: false
+          position: {100, game_height / 2, 10, 50},
+          velocity: {0, 0},
+          sprite: Players.get_sprite(),
+          granted_powers: [],
+          laser_allowed: false,
+          laser_beam: false,
+          laser_duration: 0,
+          invincibility: false,
+          name: player_name
         }
       )
 
+    state = %{
+      game_state: game_state,
+      player_id: player_id,
+      db_player: db_player
+    }
+
     # Start the periodic update
-    :timer.send_interval(state.game_tick_interval, self(), :game_tick)
-    :timer.send_interval(state.score_tick_interval, self(), :score_tick)
+    :timer.send_interval(game_state.game_tick_interval, self(), :game_tick)
+    :timer.send_interval(game_state.score_tick_interval, self(), :score_tick)
     {:ok, state}
   end
 
   @impl true
-  def handle_cast(input, state) do
-    {:noreply, GameState.handle_input(state, input)}
+  def handle_cast({:update_viewport, zoom_level, game_width, game_height}, %{game_state: gs, player_id: pid} = state) do
+    {:noreply, %{state | game_state: GameState.handle_input(gs, pid, {:update_viewport, zoom_level, game_width, game_height})}}
+  end
+
+  def handle_cast(input, %{game_state: gs, player_id: pid} = state) do
+    {:noreply, %{state | game_state: GameState.handle_input(gs, pid, input)}}
   end
 
   @impl true
-  def handle_call(:get_state, _from, state) do
-    {:reply, state, state}
+  def handle_call(:get_state, _from, %{game_state: gs} = state) do
+    {:reply, gs, state}
   end
 
   @impl true
-  def handle_info(:game_tick, %{game_id: game_id} = state) do
-    case GameState.tick(state) do
-      {:game_over, state} ->
-        calculate_score_and_update_view(state)
+  def handle_info(:game_tick, %{game_state: gs} = state) do
+    case GameState.tick(gs) do
+      {:game_over, gs} ->
+        calculate_score_and_update_view(%{state | game_state: gs})
 
-      {:ok, state} ->
+      {:ok, gs} ->
         Phoenix.PubSub.broadcast(
           Flappy.PubSub,
-          "flappy:game_state:#{game_id}",
-          {:game_state_update, GameState.strip_hitboxes(state)}
+          "flappy:game_state:#{gs.game_id}",
+          {:game_state_update, GameState.strip_hitboxes(gs)}
         )
 
-        {:noreply, state}
+        {:noreply, %{state | game_state: gs}}
     end
   end
 
-  def handle_info(:score_tick, state) do
-    {:noreply, GameState.score_tick(state)}
+  def handle_info(:score_tick, %{game_state: gs} = state) do
+    {:noreply, %{state | game_state: GameState.score_tick(gs)}}
   end
 
-  defp calculate_score_and_update_view(
-         %{player: player, game_id: game_id, current_high_scores: current_high_scores} = state
-       ) do
-    state = %{state | game_over: true}
-    Players.update_player(player, %{score: player.score})
+  defp calculate_score_and_update_view(%{game_state: gs, player_id: player_id, db_player: db_player} = state) do
+    player = gs.players[player_id]
+    game_id = gs.game_id
+    current_high_scores = gs.current_high_scores
+
+    gs = %{gs | game_over: true}
+    Players.update_player(db_player, %{score: player.score})
     high_score? = Enum.any?(current_high_scores, fn {_name, score} -> player.score > score end)
 
-    broadcast_state = GameState.strip_hitboxes(state)
+    broadcast_state = GameState.strip_hitboxes(gs)
 
     if high_score?,
       do: Phoenix.PubSub.broadcast(Flappy.PubSub, "flappy:game_state:global", {:high_score, broadcast_state}),
       else: Phoenix.PubSub.broadcast(Flappy.PubSub, "flappy:game_state:global", {:new_score, broadcast_state})
 
     Phoenix.PubSub.broadcast(Flappy.PubSub, "flappy:game_state:#{game_id}", {:game_state_update, broadcast_state})
-    {:noreply, state}
+    {:noreply, %{state | game_state: gs}}
   end
 
   ### PUBLIC API

--- a/lib/flappy/game_state.ex
+++ b/lib/flappy/game_state.ex
@@ -30,20 +30,29 @@ defmodule Flappy.GameState do
             gravity: 0,
             enemies: [],
             power_ups: [],
-            player: %{
-              position: {0, 0, 0, 0},
-              velocity: {0.0, 0.0},
-              sprite: %{image: "", size: {0, 0}, name: :default},
-              score: 0,
-              granted_powers: [],
-              laser_allowed: false,
-              laser_beam: false,
-              laser_duration: 0,
-              invincibility: false
-            },
-            explosions: []
+            players: %{},
+            explosions: [],
+            deaths_this_tick: []
 
   def new(overrides \\ []) do
+    player_id = Keyword.get(overrides, :player_id, Ecto.UUID.generate())
+
+    default_player = %{
+      position: {100.0, 300.0, 12.5, 50.0},
+      velocity: {0.0, 0.0},
+      sprite: Players.get_sprite(),
+      score: 0,
+      granted_powers: [],
+      laser_allowed: false,
+      laser_beam: false,
+      laser_duration: 0,
+      invincibility: false,
+      hitbox: nil,
+      alive: true,
+      name: "",
+      survival_time: 0
+    }
+
     defaults = %__MODULE__{
       game_id: Ecto.UUID.generate(),
       game_tick_interval: @game_tick_interval,
@@ -58,22 +67,17 @@ defmodule Flappy.GameState do
       enemies: [],
       power_ups: [],
       explosions: [],
-      player: %{
-        position: {100.0, 300.0, 12.5, 50.0},
-        velocity: {0.0, 0.0},
-        sprite: Players.get_sprite(),
-        score: 0,
-        granted_powers: [],
-        laser_allowed: false,
-        laser_beam: false,
-        laser_duration: 0,
-        invincibility: false
-      }
+      deaths_this_tick: [],
+      players: %{player_id => default_player}
     }
 
     Enum.reduce(overrides, defaults, fn
+      {:player_id, _}, acc ->
+        acc
+
       {:player, player_overrides}, acc when is_map(player_overrides) ->
-        %{acc | player: Map.merge(acc.player, player_overrides)}
+        updated_player = Map.merge(get_first_player(acc), player_overrides)
+        %{acc | players: Map.put(acc.players, first_player_id(acc), updated_player)}
 
       {key, value}, acc ->
         Map.put(acc, key, value)
@@ -82,35 +86,40 @@ defmodule Flappy.GameState do
 
   @thrust -100
 
-  def handle_input(%{player: player, zoom_level: zoom_level} = state, :go_up) do
-    {x_velocity, y_velocity} = player.velocity
-    %{state | player: %{player | velocity: {x_velocity, y_velocity + @thrust / zoom_level}}}
+  def handle_input(state, player_id, action) do
+    player = state.players[player_id]
+    if player == nil || !Map.get(player, :alive, true), do: state, else: do_handle_input(state, player_id, player, action)
   end
 
-  def handle_input(%{player: player, zoom_level: zoom_level} = state, :go_down) do
+  defp do_handle_input(state, player_id, player, :go_up) do
     {x_velocity, y_velocity} = player.velocity
-    %{state | player: %{player | velocity: {x_velocity, y_velocity - @thrust / zoom_level}}}
+    put_player(state, player_id, %{player | velocity: {x_velocity, y_velocity + @thrust / state.zoom_level}})
   end
 
-  def handle_input(%{player: player, zoom_level: zoom_level} = state, :go_right) do
+  defp do_handle_input(state, player_id, player, :go_down) do
     {x_velocity, y_velocity} = player.velocity
-    %{state | player: %{player | velocity: {x_velocity - @thrust / zoom_level, y_velocity}}}
+    put_player(state, player_id, %{player | velocity: {x_velocity, y_velocity - @thrust / state.zoom_level}})
   end
 
-  def handle_input(%{player: player, zoom_level: zoom_level} = state, :go_left) do
+  defp do_handle_input(state, player_id, player, :go_right) do
     {x_velocity, y_velocity} = player.velocity
-    %{state | player: %{player | velocity: {x_velocity + @thrust / zoom_level, y_velocity}}}
+    put_player(state, player_id, %{player | velocity: {x_velocity - @thrust / state.zoom_level, y_velocity}})
   end
 
-  def handle_input(%{player: player} = state, :fire_laser) do
+  defp do_handle_input(state, player_id, player, :go_left) do
+    {x_velocity, y_velocity} = player.velocity
+    put_player(state, player_id, %{player | velocity: {x_velocity + @thrust / state.zoom_level, y_velocity}})
+  end
+
+  defp do_handle_input(state, player_id, player, :fire_laser) do
     if player.laser_allowed do
-      %{state | player: %{player | laser_beam: true, laser_duration: 3}}
+      put_player(state, player_id, %{player | laser_beam: true, laser_duration: 3})
     else
       state
     end
   end
 
-  def handle_input(state, {:update_viewport, zoom_level, game_width, game_height}) do
+  defp do_handle_input(state, _player_id, _player, {:update_viewport, zoom_level, game_width, game_height}) do
     %{state | zoom_level: zoom_level, game_width: game_width, game_height: game_height}
   end
 
@@ -119,42 +128,95 @@ defmodule Flappy.GameState do
       state
       | enemies: Enum.map(state.enemies, &%{&1 | hitbox: nil}),
         power_ups: Enum.map(state.power_ups, &%{&1 | hitbox: nil}),
-        player: Map.put(state.player, :hitbox, nil)
+        players: Map.new(state.players, fn {id, p} -> {id, Map.put(p, :hitbox, nil)} end)
     }
   end
 
   def tick(state) do
     state =
       state
-      |> Player.update_player()
+      |> Map.put(:deaths_this_tick, [])
+      |> Player.update_players()
       |> Enemy.update_enemies()
       |> PowerUp.update_power_ups()
       |> Explosion.update_explosions()
 
-    enemies_hit_by_player = Hitbox.check_for_enemy_collisions?(state)
+    state = resolve_collisions(state)
 
-    enemies_hit_by_beam =
-      if state.player.laser_beam,
-        do: Hitbox.get_hit_enemies(state.enemies, state),
-        else: []
+    alive_count =
+      state.players
+      |> Map.values()
+      |> Enum.count(&Map.get(&1, :alive, true))
 
-    power_ups_hit = Hitbox.get_hit_power_ups(state.power_ups, state)
-
-    state =
-      state
-      |> Enemy.remove_hit_enemies(enemies_hit_by_beam ++ enemies_hit_by_player)
-      |> PowerUp.grant_power_ups(power_ups_hit)
-
-    collision? = enemies_hit_by_player != [] && !state.player.invincibility
-
-    if collision? || out_of_bounds?(state) do
+    if alive_count == 0 do
       {:game_over, %{state | game_over: true}}
     else
       {:ok, state}
     end
   end
 
-  def score_tick(%{player: player} = state) do
+  defp resolve_collisions(state) do
+    state.players
+    |> Enum.filter(fn {_id, p} -> Map.get(p, :alive, true) end)
+    |> Enum.reduce(state, fn {player_id, _player}, acc_state ->
+      # Re-read player from accumulated state (may have been updated by earlier iterations)
+      player = acc_state.players[player_id]
+
+      enemies_hit_by_body = Hitbox.check_for_enemy_collisions(player, acc_state.enemies, acc_state)
+
+      enemies_hit_by_beam =
+        if player.laser_beam,
+          do: Hitbox.get_hit_enemies(acc_state.enemies, player, acc_state),
+          else: []
+
+      power_ups_hit = Hitbox.get_hit_power_ups(acc_state.power_ups, player, acc_state)
+
+      acc_state =
+        acc_state
+        |> Enemy.remove_hit_enemies(enemies_hit_by_beam ++ enemies_hit_by_body, player_id)
+        |> PowerUp.grant_power_ups(power_ups_hit, player_id)
+
+      # Re-read player after power-ups may have changed it
+      player = acc_state.players[player_id]
+      body_collision? = enemies_hit_by_body != [] && !player.invincibility
+
+      if body_collision? || out_of_bounds?(acc_state, player_id) do
+        kill_player(acc_state, player_id)
+      else
+        acc_state
+      end
+    end)
+  end
+
+  def score_tick(state) do
+    players =
+      Map.new(state.players, fn {player_id, player} ->
+        if Map.get(player, :alive, true) do
+          {player_id, tick_player_score(player)}
+        else
+          {player_id, player}
+        end
+      end)
+
+    state = %{state | players: players}
+
+    # Use effective score (max alive player score) for enemy/power-up generation
+    max_score = effective_score(state)
+
+    state =
+      if max_score > 0 && rem(max_score, 2) == 0,
+        do: %{state | enemies: Enemy.maybe_generate_enemy(state)},
+        else: state
+
+    state =
+      if max_score > 0 && rem(max_score, 10) == 0,
+        do: %{state | power_ups: PowerUp.generate_power_up(state)},
+        else: state
+
+    state
+  end
+
+  defp tick_player_score(player) do
     granted_powers =
       player.granted_powers
       |> Enum.uniq_by(fn {power, _duration} -> power end)
@@ -167,30 +229,141 @@ defmodule Flappy.GameState do
     %{laser_allowed: laser_allowed, invincibility: invincibility, sprite: sprite} =
       PowerUp.derive_power_flags(granted_powers)
 
-    player =
-      Map.merge(player, %{
-        score: player.score + 1,
-        granted_powers: granted_powers,
-        laser_allowed: laser_allowed,
-        invincibility: invincibility,
-        sprite: sprite
-      })
-
-    state = %{state | player: player}
-    state = if rem(player.score, 2) == 0, do: %{state | enemies: Enemy.maybe_generate_enemy(state)}, else: state
-    state = if rem(player.score, 10) == 0, do: %{state | power_ups: PowerUp.generate_power_up(state)}, else: state
-
-    state
+    Map.merge(player, %{
+      score: player.score + 1,
+      survival_time: Map.get(player, :survival_time, 0) + 1,
+      granted_powers: granted_powers,
+      laser_allowed: laser_allowed,
+      invincibility: invincibility,
+      sprite: sprite
+    })
   end
 
-  defp out_of_bounds?(%{
-         player: %{position: {_x, _y, x_pos, y_pos}, sprite: %{size: {player_length, player_height}}},
-         game_width: game_width,
-         game_height: game_height
-       }) do
+  # --- Multiplayer lifecycle ---
+
+  def add_player(state, player_id, name \\ "") do
+    player = %{
+      position: {100.0, state.game_height / 2, 12.5, 50.0},
+      velocity: {0.0, 0.0},
+      sprite: Players.get_sprite(),
+      score: 0,
+      granted_powers: [],
+      laser_allowed: false,
+      laser_beam: false,
+      laser_duration: 0,
+      invincibility: false,
+      hitbox: nil,
+      alive: true,
+      name: name,
+      survival_time: 0
+    }
+
+    %{state | players: Map.put(state.players, player_id, player)}
+  end
+
+  def remove_player(state, player_id) do
+    player = state.players[player_id]
+
+    explosions =
+      if player && Map.get(player, :alive, true) do
+        explosion = %Explosion{
+          duration: 3,
+          position: player.position,
+          velocity: {0, 0},
+          sprite: %{image: "/images/explosion.svg", size: {100, 100}, name: :explosion},
+          id: Ecto.UUID.generate()
+        }
+
+        [explosion | state.explosions]
+      else
+        state.explosions
+      end
+
+    %{state | players: Map.delete(state.players, player_id), explosions: explosions}
+  end
+
+  def crown_holder(state) do
+    state.players
+    |> Enum.filter(fn {_id, p} -> Map.get(p, :alive, true) end)
+    |> Enum.max_by(fn {_id, p} -> Map.get(p, :survival_time, 0) end, fn -> nil end)
+    |> case do
+      nil -> nil
+      {id, _player} -> id
+    end
+  end
+
+  def last_bird_standing?(state) do
+    alive =
+      state.players
+      |> Map.values()
+      |> Enum.filter(&Map.get(&1, :alive, true))
+
+    dead =
+      state.players
+      |> Map.values()
+      |> Enum.reject(&Map.get(&1, :alive, true))
+
+    length(alive) == 1 && length(dead) >= 1
+  end
+
+  def alive_count(state) do
+    state.players
+    |> Map.values()
+    |> Enum.count(&Map.get(&1, :alive, true))
+  end
+
+  # --- Helpers ---
+
+  defp put_player(state, player_id, player) do
+    %{state | players: Map.put(state.players, player_id, player)}
+  end
+
+  defp kill_player(state, player_id) do
+    player = state.players[player_id]
+
+    explosion = %Explosion{
+      duration: 3,
+      position: player.position,
+      velocity: {0, 0},
+      sprite: %{image: "/images/explosion.svg", size: {100, 100}, name: :explosion},
+      id: Ecto.UUID.generate()
+    }
+
+    updated_player = Map.put(player, :alive, false)
+
+    %{
+      state
+      | players: Map.put(state.players, player_id, updated_player),
+        explosions: [explosion | state.explosions],
+        deaths_this_tick: [player_id | state.deaths_this_tick]
+    }
+  end
+
+  defp out_of_bounds?(state, player_id) do
+    player = state.players[player_id]
+    {_x, _y, x_pos, y_pos} = player.position
+    {player_length, player_height} = player.sprite.size
+
     y_pos < 0 ||
-      y_pos > 100 - player_height / game_height * 100 ||
-      x_pos < 0 - player_length / game_width * 100 ||
+      y_pos > 100 - player_height / state.game_height * 100 ||
+      x_pos < 0 - player_length / state.game_width * 100 ||
       x_pos > 100
+  end
+
+  defp effective_score(%{players: players}) do
+    players
+    |> Map.values()
+    |> Enum.filter(&Map.get(&1, :alive, true))
+    |> Enum.map(& &1.score)
+    |> Enum.max(fn -> 0 end)
+  end
+
+  defp first_player_id(state) do
+    state.players |> Map.keys() |> List.first()
+  end
+
+  defp get_first_player(state) do
+    {_id, player} = state.players |> Enum.at(0)
+    player
   end
 end

--- a/lib/flappy/hitbox.ex
+++ b/lib/flappy/hitbox.ex
@@ -8,18 +8,18 @@ defmodule Flappy.Hitbox do
   """
   alias Flappy.Position
 
-  def get_hit_enemies(enemies, game_state) do
-    laser_hitbox = laser_hitbox(game_state)
+  def get_hit_enemies(enemies, player, game_state) do
+    laser_hitbox = laser_hitbox(player, game_state)
 
     detect_multiple_hits(enemies, laser_hitbox, game_state)
   end
 
-  def get_hit_power_ups(power_ups, %{player: player} = state) do
+  def get_hit_power_ups(power_ups, player, state) do
     p_hitbox = get_or_compute_player_hitbox(player, state)
     detect_multiple_hits(power_ups, p_hitbox, state)
   end
 
-  def check_for_enemy_collisions?(%{player: player, enemies: enemies} = state) do
+  def check_for_enemy_collisions(player, enemies, state) do
     p_hitbox = get_or_compute_player_hitbox(player, state)
     detect_multiple_hits(enemies, p_hitbox, state)
   end
@@ -72,9 +72,9 @@ defmodule Flappy.Hitbox do
     Polygons.Polygon.make([point_one, point_two, point_three, point_four, point_five, point_six])
   end
 
-  defp laser_hitbox(game_state) do
-    x = Position.bird_x_eye_position(game_state)
-    y = Position.bird_y_eye_position(game_state)
+  defp laser_hitbox(player, game_state) do
+    x = Position.bird_x_eye_position(player, game_state.game_width)
+    y = Position.bird_y_eye_position(player, game_state.game_height)
     w = 100
     h = 1
 

--- a/lib/flappy/multiplayer_engine.ex
+++ b/lib/flappy/multiplayer_engine.ex
@@ -6,6 +6,8 @@ defmodule Flappy.MultiplayerEngine do
 
   use GenServer
 
+  require Logger
+
   alias Flappy.GameState
   alias Flappy.MultiplayerScores
 
@@ -48,11 +50,12 @@ defmodule Flappy.MultiplayerEngine do
 
   @impl true
   def handle_call({:join, player_id, player_name}, _from, state) do
-    was_empty = map_size(state.players) == 0
+    needs_fresh_start = map_size(state.players) == 0 || state.game_over
 
     state =
-      if was_empty do
-        # First player: fresh state + start timers
+      if needs_fresh_start do
+        # First player or game_over: fresh state + start timers
+        stop_timers(state)
         state = fresh_state()
         state = GameState.add_player(state, player_id, player_name)
         start_timers(state)
@@ -74,13 +77,11 @@ defmodule Flappy.MultiplayerEngine do
 
     # Save survival time if player was alive
     if player && Map.get(player, :alive, true) do
-      survival_ms = Map.get(player, :survival_time, 0) * state.score_tick_interval
-      if survival_ms > 0, do: MultiplayerScores.save_score!(player.name, survival_ms)
+      save_score(player, state)
     end
 
     state = GameState.remove_player(state, player_id)
 
-    # Broadcast the death/leave
     broadcast(state)
 
     # If no players left, stop timers and reset
@@ -105,7 +106,6 @@ defmodule Flappy.MultiplayerEngine do
 
   @impl true
   def handle_info(:game_tick, %{game_over: true} = state) do
-    # Already game over — don't keep ticking or saving scores
     {:noreply, state}
   end
 
@@ -115,7 +115,9 @@ defmodule Flappy.MultiplayerEngine do
     else
       case GameState.tick(state) do
         {:game_over, state} ->
-          save_all_scores(state)
+          # All players dead — save only those not already saved by handle_deaths
+          save_unsaved_scores(state)
+          stop_timers(state)
           broadcast(state)
           {:noreply, state}
 
@@ -162,7 +164,6 @@ defmodule Flappy.MultiplayerEngine do
   end
 
   defp start_timers(state) do
-    # Store timer refs on the process dictionary for cleanup
     {:ok, game_ref} = :timer.send_interval(state.game_tick_interval, self(), :game_tick)
     {:ok, score_ref} = :timer.send_interval(state.score_tick_interval, self(), :score_tick)
     Process.put(:game_timer, game_ref)
@@ -186,21 +187,34 @@ defmodule Flappy.MultiplayerEngine do
     )
   end
 
+  # Save scores for players who just died this tick
   defp handle_deaths(state) do
     Enum.each(state.deaths_this_tick, fn player_id ->
       player = state.players[player_id]
+      if player, do: save_score(player, state)
+    end)
+  end
 
-      if player do
-        survival_ms = Map.get(player, :survival_time, 0) * state.score_tick_interval
-        if survival_ms > 0, do: MultiplayerScores.save_score!(player.name, survival_ms)
+  # On game_over, only save players NOT already in deaths_this_tick
+  # (those were already saved by handle_deaths in prior ticks)
+  defp save_unsaved_scores(state) do
+    already_saved = MapSet.new(state.deaths_this_tick)
+
+    Enum.each(state.players, fn {player_id, player} ->
+      unless MapSet.member?(already_saved, player_id) do
+        save_score(player, state)
       end
     end)
   end
 
-  defp save_all_scores(state) do
-    Enum.each(state.players, fn {_id, player} ->
-      survival_ms = Map.get(player, :survival_time, 0) * state.score_tick_interval
-      if survival_ms > 0, do: MultiplayerScores.save_score!(player.name, survival_ms)
-    end)
+  defp save_score(player, state) do
+    survival_ms = Map.get(player, :survival_time, 0) * state.score_tick_interval
+
+    if survival_ms > 0 do
+      case MultiplayerScores.save_score(player.name, survival_ms) do
+        {:ok, _} -> :ok
+        {:error, reason} -> Logger.error("Failed to save multiplayer score: #{inspect(reason)}")
+      end
+    end
   end
 end

--- a/lib/flappy/multiplayer_engine.ex
+++ b/lib/flappy/multiplayer_engine.ex
@@ -1,0 +1,199 @@
+defmodule Flappy.MultiplayerEngine do
+  @moduledoc """
+  Global multiplayer game server. One instance for all multiplayer players.
+  Manages shared game state, player join/leave, and broadcasts via PubSub.
+  """
+
+  use GenServer
+
+  alias Flappy.GameState
+  alias Flappy.MultiplayerScores
+
+  @pubsub_topic "flappy:multiplayer"
+
+  # --- Client API ---
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def join(player_id, player_name) do
+    GenServer.call(__MODULE__, {:join, player_id, player_name})
+  end
+
+  def leave(player_id) do
+    GenServer.cast(__MODULE__, {:leave, player_id})
+  end
+
+  def get_state do
+    GenServer.call(__MODULE__, :get_state)
+  end
+
+  def player_input(player_id, action) do
+    GenServer.cast(__MODULE__, {:input, player_id, action})
+  end
+
+  def update_viewport(zoom_level, game_width, game_height) do
+    GenServer.cast(__MODULE__, {:update_viewport, zoom_level, game_width, game_height})
+  end
+
+  def pubsub_topic, do: @pubsub_topic
+
+  # --- Server ---
+
+  @impl true
+  def init(:ok) do
+    {:ok, fresh_state()}
+  end
+
+  @impl true
+  def handle_call({:join, player_id, player_name}, _from, state) do
+    was_empty = map_size(state.players) == 0
+
+    state =
+      if was_empty do
+        # First player: fresh state + start timers
+        state = fresh_state()
+        state = GameState.add_player(state, player_id, player_name)
+        start_timers(state)
+        state
+      else
+        GameState.add_player(state, player_id, player_name)
+      end
+
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:get_state, _from, state) do
+    {:reply, state, state}
+  end
+
+  @impl true
+  def handle_cast({:leave, player_id}, state) do
+    player = state.players[player_id]
+
+    # Save survival time if player was alive
+    if player && Map.get(player, :alive, true) do
+      survival_ms = Map.get(player, :survival_time, 0) * state.score_tick_interval
+      if survival_ms > 0, do: MultiplayerScores.save_score!(player.name, survival_ms)
+    end
+
+    state = GameState.remove_player(state, player_id)
+
+    # Broadcast the death/leave
+    broadcast(state)
+
+    # If no players left, stop timers and reset
+    state =
+      if map_size(state.players) == 0 do
+        stop_timers(state)
+        fresh_state()
+      else
+        state
+      end
+
+    {:noreply, state}
+  end
+
+  def handle_cast({:input, player_id, action}, state) do
+    {:noreply, GameState.handle_input(state, player_id, action)}
+  end
+
+  def handle_cast({:update_viewport, zoom_level, game_width, game_height}, state) do
+    {:noreply, %{state | zoom_level: zoom_level, game_width: game_width, game_height: game_height}}
+  end
+
+  @impl true
+  def handle_info(:game_tick, state) do
+    if map_size(state.players) == 0 do
+      {:noreply, state}
+    else
+      case GameState.tick(state) do
+        {:game_over, state} ->
+          # All players dead - save scores and broadcast
+          save_all_scores(state)
+          broadcast(state)
+          {:noreply, state}
+
+        {:ok, state} ->
+          # Handle any deaths this tick
+          handle_deaths(state)
+          broadcast(state)
+          {:noreply, state}
+      end
+    end
+  end
+
+  def handle_info(:score_tick, state) do
+    if map_size(state.players) == 0 do
+      {:noreply, state}
+    else
+      {:noreply, GameState.score_tick(state)}
+    end
+  end
+
+  # --- Private ---
+
+  defp fresh_state do
+    %GameState{
+      game_id: "multiplayer",
+      game_tick_interval: 15,
+      score_tick_interval: 1000,
+      score_multiplier: 10,
+      difficulty_score: 400,
+      game_over: false,
+      game_height: 600,
+      game_width: 800,
+      zoom_level: 1,
+      gravity: 175,
+      enemies: [],
+      power_ups: [],
+      players: %{},
+      explosions: [],
+      deaths_this_tick: []
+    }
+  end
+
+  defp start_timers(state) do
+    # Store timer refs on the process dictionary for cleanup
+    {:ok, game_ref} = :timer.send_interval(state.game_tick_interval, self(), :game_tick)
+    {:ok, score_ref} = :timer.send_interval(state.score_tick_interval, self(), :score_tick)
+    Process.put(:game_timer, game_ref)
+    Process.put(:score_timer, score_ref)
+  end
+
+  defp stop_timers(_state) do
+    game_ref = Process.get(:game_timer)
+    score_ref = Process.get(:score_timer)
+    if game_ref, do: :timer.cancel(game_ref)
+    if score_ref, do: :timer.cancel(score_ref)
+    Process.delete(:game_timer)
+    Process.delete(:score_timer)
+  end
+
+  defp broadcast(state) do
+    Phoenix.PubSub.broadcast(
+      Flappy.PubSub,
+      @pubsub_topic,
+      {:multiplayer_state, GameState.strip_hitboxes(state)}
+    )
+  end
+
+  defp handle_deaths(state) do
+    Enum.each(state.deaths_this_tick, fn player_id ->
+      player = state.players[player_id]
+
+      if player do
+        survival_ms = Map.get(player, :survival_time, 0) * state.score_tick_interval
+        if survival_ms > 0, do: MultiplayerScores.save_score!(player.name, survival_ms)
+      end
+    end)
+  end
+
+  defp save_all_scores(state) do
+    Enum.each(state.players, fn {_id, player} ->
+      survival_ms = Map.get(player, :survival_time, 0) * state.score_tick_interval
+      if survival_ms > 0, do: MultiplayerScores.save_score!(player.name, survival_ms)
+    end)
+  end
+end

--- a/lib/flappy/multiplayer_engine.ex
+++ b/lib/flappy/multiplayer_engine.ex
@@ -104,24 +104,31 @@ defmodule Flappy.MultiplayerEngine do
   end
 
   @impl true
+  def handle_info(:game_tick, %{game_over: true} = state) do
+    # Already game over — don't keep ticking or saving scores
+    {:noreply, state}
+  end
+
   def handle_info(:game_tick, state) do
     if map_size(state.players) == 0 do
       {:noreply, state}
     else
       case GameState.tick(state) do
         {:game_over, state} ->
-          # All players dead - save scores and broadcast
           save_all_scores(state)
           broadcast(state)
           {:noreply, state}
 
         {:ok, state} ->
-          # Handle any deaths this tick
           handle_deaths(state)
           broadcast(state)
           {:noreply, state}
       end
     end
+  end
+
+  def handle_info(:score_tick, %{game_over: true} = state) do
+    {:noreply, state}
   end
 
   def handle_info(:score_tick, state) do

--- a/lib/flappy/multiplayer_scores.ex
+++ b/lib/flappy/multiplayer_scores.ex
@@ -7,12 +7,12 @@ defmodule Flappy.MultiplayerScores do
   alias Flappy.MultiplayerScores.Score
   alias Flappy.Repo
 
-  def save_score!(name, survival_time_ms) do
+  def save_score(name, survival_time_ms) do
     version = get_version()
 
     %Score{}
     |> Score.changeset(%{name: name, survival_time_ms: survival_time_ms, version: version})
-    |> Repo.insert!()
+    |> Repo.insert()
   end
 
   def get_leaderboard(limit, version) do

--- a/lib/flappy/multiplayer_scores.ex
+++ b/lib/flappy/multiplayer_scores.ex
@@ -1,0 +1,23 @@
+defmodule Flappy.MultiplayerScores do
+  @moduledoc """
+  Context for multiplayer leaderboard queries.
+  """
+  import Ecto.Query
+
+  alias Flappy.MultiplayerScores.Score
+  alias Flappy.Repo
+
+  def save_score!(name, survival_time_ms) do
+    %Score{}
+    |> Score.changeset(%{name: name, survival_time_ms: survival_time_ms})
+    |> Repo.insert!()
+  end
+
+  def get_leaderboard(limit \\ 100) do
+    Score
+    |> select([s], %{name: s.name, survival_time_ms: s.survival_time_ms})
+    |> order_by(desc: :survival_time_ms)
+    |> limit(^limit)
+    |> Repo.all()
+  end
+end

--- a/lib/flappy/multiplayer_scores.ex
+++ b/lib/flappy/multiplayer_scores.ex
@@ -8,16 +8,32 @@ defmodule Flappy.MultiplayerScores do
   alias Flappy.Repo
 
   def save_score!(name, survival_time_ms) do
+    version = get_version()
+
     %Score{}
-    |> Score.changeset(%{name: name, survival_time_ms: survival_time_ms})
+    |> Score.changeset(%{name: name, survival_time_ms: survival_time_ms, version: version})
     |> Repo.insert!()
   end
 
-  def get_leaderboard(limit \\ 100) do
+  def get_leaderboard(limit, version) do
+    version = to_integer(version)
+
     Score
+    |> where([s], s.version == ^version or is_nil(s.version))
     |> select([s], %{name: s.name, survival_time_ms: s.survival_time_ms})
     |> order_by(desc: :survival_time_ms)
     |> limit(^limit)
     |> Repo.all()
   end
+
+  def get_leaderboard(limit) do
+    get_leaderboard(limit, get_version())
+  end
+
+  defp get_version do
+    to_integer(Application.get_env(:flappy, :game_version, "1"))
+  end
+
+  defp to_integer(v) when is_integer(v), do: v
+  defp to_integer(v) when is_binary(v), do: String.to_integer(v)
 end

--- a/lib/flappy/multiplayer_scores/score.ex
+++ b/lib/flappy/multiplayer_scores/score.ex
@@ -1,0 +1,18 @@
+defmodule Flappy.MultiplayerScores.Score do
+  @moduledoc false
+  use Ecto.Schema
+  alias Ecto.Changeset
+
+  schema "multiplayer_scores" do
+    field :name, :string
+    field :survival_time_ms, :integer
+
+    timestamps()
+  end
+
+  def changeset(score, attrs) do
+    score
+    |> Changeset.cast(attrs, [:name, :survival_time_ms])
+    |> Changeset.validate_required([:name, :survival_time_ms])
+  end
+end

--- a/lib/flappy/multiplayer_scores/score.ex
+++ b/lib/flappy/multiplayer_scores/score.ex
@@ -6,13 +6,14 @@ defmodule Flappy.MultiplayerScores.Score do
   schema "multiplayer_scores" do
     field :name, :string
     field :survival_time_ms, :integer
+    field :version, :integer
 
     timestamps()
   end
 
   def changeset(score, attrs) do
     score
-    |> Changeset.cast(attrs, [:name, :survival_time_ms])
+    |> Changeset.cast(attrs, [:name, :survival_time_ms, :version])
     |> Changeset.validate_required([:name, :survival_time_ms])
   end
 end

--- a/lib/flappy/players/player.ex
+++ b/lib/flappy/players/player.ex
@@ -36,13 +36,26 @@ defmodule Flappy.Players.Player do
     |> Changeset.validate_required([:name, :score, :version])
   end
 
-  def update_player(%{player: player, gravity: gravity, game_width: game_width, game_height: game_height} = state) do
+  def update_players(%{players: players, gravity: gravity, game_width: game_width, game_height: game_height} = state) do
+    updated_players =
+      Map.new(players, fn {player_id, player} ->
+        if Map.get(player, :alive, true) do
+          {player_id, update_single_player(player, gravity, game_width, game_height, state.game_tick_interval)}
+        else
+          {player_id, player}
+        end
+      end)
+
+    %{state | players: updated_players}
+  end
+
+  defp update_single_player(player, gravity, game_width, game_height, game_tick_interval) do
     {x_position, y_position, _x_percent, _y_percent} = player.position
     {x_velocity, y_velocity} = player.velocity
 
-    new_y_velocity = Float.floor(y_velocity + gravity * (state.game_tick_interval / 1000), 2)
-    new_y_position = Float.floor(y_position + new_y_velocity * (state.game_tick_interval / 1000), 2)
-    new_x_position = Float.floor(x_position + x_velocity * (state.game_tick_interval / 1000), 2)
+    new_y_velocity = Float.floor(y_velocity + gravity * (game_tick_interval / 1000), 2)
+    new_y_position = Float.floor(y_position + new_y_velocity * (game_tick_interval / 1000), 2)
+    new_x_position = Float.floor(x_position + x_velocity * (game_tick_interval / 1000), 2)
     laser_on? = player.laser_duration > 0
     laser_duration = if laser_on?, do: player.laser_duration - 1, else: 0
 
@@ -51,15 +64,12 @@ defmodule Flappy.Players.Player do
     {sprite_w, sprite_h} = player.sprite.size
     hitbox = Hitbox.player_hitbox(x_percent, y_percent, sprite_w, sprite_h, game_width, game_height)
 
-    player =
-      Map.merge(player, %{
-        position: {new_x_position, new_y_position, x_percent, y_percent},
-        velocity: {x_velocity, new_y_velocity},
-        laser_beam: laser_on?,
-        laser_duration: laser_duration,
-        hitbox: hitbox
-      })
-
-    %{state | player: player}
+    Map.merge(player, %{
+      position: {new_x_position, new_y_position, x_percent, y_percent},
+      velocity: {x_velocity, new_y_velocity},
+      laser_beam: laser_on?,
+      laser_duration: laser_duration,
+      hitbox: hitbox
+    })
   end
 end

--- a/lib/flappy/position.ex
+++ b/lib/flappy/position.ex
@@ -9,15 +9,16 @@ defmodule Flappy.Position do
     {percentage_x, percentage_y}
   end
 
-  def bird_x_eye_position(%{player: %{sprite: %{size: {w, _h}}, position: {_, _, x_pos, _y_pos}}, game_width: game_width}) do
+  def bird_x_eye_position(player, game_width) do
+    {w, _h} = player.sprite.size
+    {_, _, x_pos, _y_pos} = player.position
     w = w / game_width * 100
     x_pos + w * 0.81
   end
 
-  def bird_y_eye_position(%{
-        player: %{sprite: %{size: {_w, h}}, position: {_, _, _x_pos, y_pos}},
-        game_height: game_height
-      }) do
+  def bird_y_eye_position(player, game_height) do
+    {_w, h} = player.sprite.size
+    {_, _, _x_pos, y_pos} = player.position
     h = h / game_height * 100
     y_pos + h * 0.05
   end

--- a/lib/flappy/power_up.ex
+++ b/lib/flappy/power_up.ex
@@ -78,7 +78,8 @@ defmodule Flappy.PowerUp do
     %{state | power_ups: power_ups}
   end
 
-  def grant_power_ups(%{player: player} = state, power_ups_hit) do
+  def grant_power_ups(state, power_ups_hit, player_id) do
+    player = state.players[player_id]
     hit_ids = Enum.map(power_ups_hit, & &1.id)
 
     {power_ups, granted_powers} =
@@ -99,7 +100,7 @@ defmodule Flappy.PowerUp do
           new_explosion = %Explosion{
             duration: 3,
             position: power_up.position,
-            velocity: power_up.velocity,
+            velocity: {0, 0},
             sprite: %{image: "/images/explosion.svg", size: {500, 500}, name: :explosion},
             id: Ecto.UUID.generate()
           }
@@ -127,7 +128,7 @@ defmodule Flappy.PowerUp do
     %{
       state
       | power_ups: power_ups,
-        player: player,
+        players: Map.put(state.players, player_id, player),
         enemies: enemies,
         explosions: explosions
     }

--- a/lib/flappy_web/live/flappy_live.ex
+++ b/lib/flappy_web/live/flappy_live.ex
@@ -65,9 +65,15 @@ defmodule FlappyWeb.FlappyLive do
             />
           </div>
 
-          <.button type="submit" class="bg-blue-500 rounded">
-            <p class="text-4xl text-white">Play</p>
-          </.button>
+          <div class="flex flex-row gap-4">
+            <.button type="submit" class="bg-blue-500 rounded">
+              <p class="text-4xl text-white">Singleplayer</p>
+            </.button>
+
+            <.button type="button" class="bg-purple-600 rounded" phx-click="go_multiplayer">
+              <p class="text-4xl text-white">Multiplayer</p>
+            </.button>
+          </div>
         </.simple_form>
 
         <p class="text-white text-2xl text-center">
@@ -76,11 +82,11 @@ defmodule FlappyWeb.FlappyLive do
       </div>
       <%!-- Score container --%>
       <div :if={@game_state.game_over} class="flex flex-col items-center justify-center h-screen z-50">
-        <p :if={@game_state.player.score != 69} class="text-white text-4xl z-50">
+        <p :if={get_player_field(@game_state, :score) != 69} class="text-white text-4xl z-50">
           YOU LOSE! I SAY GOOD DAY SIR!
         </p>
         <br />
-        <p class="text-white text-4xl z-50">Your final score was {@game_state.player.score}</p>
+        <p class="text-white text-4xl z-50">Your final score was {get_player_field(@game_state, :score)}</p>
 
         <.button phx-click="play_again" class="bg-blue-500 text-white px-4 py-2 rounded mt-4 z-50">
           <p class="p-4 text-4xl text-white">Play Again?</p>
@@ -95,27 +101,30 @@ defmodule FlappyWeb.FlappyLive do
         id="score-container"
         class=" z-50 absolute top-0 left-0 ml-11 mt-11 bg-black rounded-md p-2"
       >
-        <p class="text-white text-4xl">Score: {@game_state.player.score}</p>
+        <p class="text-white text-4xl">Score: {get_player_field(@game_state, :score)}</p>
       </div>
       <%!-- Game Area --%>
       <div id="game-area" phx-hook="ResizeHook" class="game-area w-screen h-screen -z-0">
         <%!-- Player --%>
-        <div
-          :if={@game_started && !@game_state.game_over}
-          id="bird-container"
-          phx-window-keydown="player_action"
-          style={"position: absolute; left: #{elem(@game_state.player.position, 2)}%; top: #{elem(@game_state.player.position, 3)}%; "}
-        >
-          <img src={@game_state.player.sprite.image} class={@sprite_class} />
-        </div>
+        <%= if @game_started && !@game_state.game_over do %>
+          <% player = get_player(@game_state) %>
+          <div
+            :if={player}
+            id="bird-container"
+            phx-window-keydown="player_action"
+            style={"position: absolute; left: #{elem(player.position, 2)}%; top: #{elem(player.position, 3)}%; "}
+          >
+            <img src={player.sprite.image} class={@sprite_class} />
+          </div>
 
-        <div
-          :if={@game_state.player.laser_beam && !@game_state.game_over}
-          id="laser-beam"
-          class="absolute bg-red-900 h-1 rounded-md"
-          style={"left: #{Position.bird_x_eye_position(@game_state)}%; top: #{Position.bird_y_eye_position(@game_state)}%; width: #{100 - elem(@game_state.player.position, 2)}%;"}
-        >
-        </div>
+          <div
+            :if={player && player.laser_beam && !@game_state.game_over}
+            id="laser-beam"
+            class="absolute bg-red-900 h-1 rounded-md"
+            style={"left: #{Position.bird_x_eye_position(player, @game_state.game_width)}%; top: #{Position.bird_y_eye_position(player, @game_state.game_height)}%; width: #{100 - elem(player.position, 2)}%;"}
+          >
+          </div>
+        <% end %>
         <%!-- Enemies --%>
         <%= for %{position: {_, _, x_pos, y_pos}} = enemy <- @game_state.enemies do %>
           <div
@@ -192,6 +201,10 @@ defmodule FlappyWeb.FlappyLive do
      |> assign(:current_high_scores, [])
      |> assign(:game_state, %GameState{})
      |> assign(:game_height, game_height)}
+  end
+
+  def handle_event("go_multiplayer", _, socket) do
+    {:noreply, push_navigate(socket, to: ~p"/multiplayer")}
   end
 
   def handle_event(
@@ -275,7 +288,8 @@ defmodule FlappyWeb.FlappyLive do
     end
   end
 
-  def handle_info({:game_state_update, game_state}, %{assigns: %{engine_pid: engine_pid}} = socket) do
+  def handle_info({:game_state_update, game_state}, %{assigns: %{engine_pid: engine_pid}} = socket)
+      when is_pid(engine_pid) do
     if game_state.game_over do
       if Process.alive?(engine_pid) do
         FlappyEngine.stop_engine(engine_pid)
@@ -283,7 +297,12 @@ defmodule FlappyWeb.FlappyLive do
 
       {:noreply, assign(socket, :game_state, %{game_state | game_over: true})}
     else
-      sprite_class = if game_state.player.laser_allowed, do: "filter drop-shadow-[0_5px_10px_rgba(255,0,0,0.7)]", else: ""
+      player = get_player(game_state)
+
+      sprite_class =
+        if player && player.laser_allowed,
+          do: "filter drop-shadow-[0_5px_10px_rgba(255,0,0,0.7)]",
+          else: ""
 
       {:noreply, socket |> assign(:sprite_class, sprite_class) |> assign(:game_state, game_state)}
     end
@@ -294,9 +313,14 @@ defmodule FlappyWeb.FlappyLive do
   end
 
   def handle_info(
-        {:high_score, %{player: %{name: player_name, score: score}}},
+        {:high_score, game_state},
         %{assigns: %{messages: existing_messages, current_high_scores: current_high_scores}} = socket
       ) do
+    # Get player info from the first player in the state
+    player = get_player(game_state)
+    player_name = player.name
+    score = player.score
+
     new_high_scores =
       [{player_name, score} | current_high_scores]
       |> Enum.sort_by(fn {_, score} -> score end, :desc)
@@ -320,9 +344,13 @@ defmodule FlappyWeb.FlappyLive do
   end
 
   def handle_info(
-        {:new_score, %{player: %{name: player_name, score: score}}},
+        {:new_score, game_state},
         %{assigns: %{messages: existing_messages}} = socket
       ) do
+    player = get_player(game_state)
+    player_name = player.name
+    score = player.score
+
     mean_message =
       cond do
         score < 50 ->
@@ -341,7 +369,7 @@ defmodule FlappyWeb.FlappyLive do
 
         true ->
           Enum.random([
-            "I’ve seen rocks with better reflexes!",
+            "I've seen rocks with better reflexes!",
             "A Phoenix should rise… not crash and burn!",
             "Not every bird is meant to soar, I guess."
           ])
@@ -379,6 +407,19 @@ defmodule FlappyWeb.FlappyLive do
      |> assign(:engine_pid, engine_pid)
      |> assign(:game_state, game_state)
      |> assign(:game_started, true)}
+  end
+
+  # Helper to get the first (singleplayer) player from the players map
+  defp get_player(%{players: players}) when map_size(players) > 0 do
+    {_id, player} = Enum.at(players, 0)
+    player
+  end
+
+  defp get_player(_), do: %{position: {0, 0, 0, 0}, velocity: {0.0, 0.0}, sprite: %{image: "", size: {0, 0}, name: :default}, score: 0, laser_beam: false, laser_allowed: false, alive: true, name: ""}
+
+  defp get_player_field(game_state, field) do
+    player = get_player(game_state)
+    Map.get(player, field, 0)
   end
 
   ### Used to generate z index between 1 and 50

--- a/lib/flappy_web/live/flappy_live.ex
+++ b/lib/flappy_web/live/flappy_live.ex
@@ -66,11 +66,11 @@ defmodule FlappyWeb.FlappyLive do
           </div>
 
           <div class="flex flex-row gap-4">
-            <.button type="submit" class="bg-blue-500 rounded">
+            <.button type="submit" name="mode" value="singleplayer" class="bg-blue-500 rounded">
               <p class="text-4xl text-white">Singleplayer</p>
             </.button>
 
-            <.button type="button" class="bg-purple-600 rounded" phx-click="go_multiplayer">
+            <.button type="submit" name="mode" value="multiplayer" class="bg-purple-600 rounded">
               <p class="text-4xl text-white">Multiplayer</p>
             </.button>
           </div>
@@ -203,10 +203,6 @@ defmodule FlappyWeb.FlappyLive do
      |> assign(:game_height, game_height)}
   end
 
-  def handle_event("go_multiplayer", _, socket) do
-    {:noreply, push_navigate(socket, to: ~p"/multiplayer")}
-  end
-
   def handle_event(
         "play_again",
         _,
@@ -262,6 +258,19 @@ defmodule FlappyWeb.FlappyLive do
 
   def handle_event("player_action", _, socket) do
     {:noreply, socket}
+  end
+
+  def handle_event("enter_name", %{"player_name" => player_name, "mode" => "multiplayer"}, socket) do
+    if String.length(player_name) in 1..10 do
+      player_name =
+        player_name
+        |> HtmlSanitizeEx.strip_tags()
+        |> sanitize_player_name()
+
+      {:noreply, push_navigate(socket, to: ~p"/multiplayer?name=#{player_name}")}
+    else
+      {:noreply, put_flash(socket, :error, "Name must be between 1 and 10 characters")}
+    end
   end
 
   def handle_event("enter_name", %{"player_name" => player_name}, socket) do

--- a/lib/flappy_web/live/flappy_multiplayer_live.ex
+++ b/lib/flappy_web/live/flappy_multiplayer_live.ex
@@ -218,6 +218,14 @@ defmodule FlappyWeb.FlappyMultiplayerLive do
      |> assign(:zoom_level, zoom_level)}
   end
 
+  def handle_params(%{"name" => name}, _uri, %{assigns: %{joined: false}} = socket) when byte_size(name) > 0 do
+    {:noreply, join_game(name, socket)}
+  end
+
+  def handle_params(_params, _uri, socket) do
+    {:noreply, socket}
+  end
+
   def terminate(_reason, %{assigns: %{joined: true, player_id: player_id}} = _socket) do
     MultiplayerEngine.leave(player_id)
     :ok
@@ -227,34 +235,14 @@ defmodule FlappyWeb.FlappyMultiplayerLive do
 
   def handle_event("join_game", %{"player_name" => player_name}, socket) do
     if String.length(player_name) in 1..10 do
-      player_name =
-        player_name
-        |> HtmlSanitizeEx.strip_tags()
-        |> sanitize_player_name()
-
-      player_id = Ecto.UUID.generate()
-      :ok = MultiplayerEngine.join(player_id, player_name)
-
-      {:noreply,
-       socket
-       |> assign(:joined, true)
-       |> assign(:dead, false)
-       |> assign(:player_id, player_id)
-       |> assign(:player_name, player_name)}
+      {:noreply, join_game(player_name, socket)}
     else
       {:noreply, put_flash(socket, :error, "Name must be between 1 and 10 characters")}
     end
   end
 
   def handle_event("rejoin", _, %{assigns: %{player_name: player_name}} = socket) do
-    player_id = Ecto.UUID.generate()
-    :ok = MultiplayerEngine.join(player_id, player_name)
-
-    {:noreply,
-     socket
-     |> assign(:dead, false)
-     |> assign(:player_id, player_id)
-     |> assign(:last_bird_standing, false)}
+    {:noreply, join_game(player_name, socket)}
   end
 
   def handle_event(
@@ -375,6 +363,26 @@ defmodule FlappyWeb.FlappyMultiplayerLive do
     |> binary_part(0, 2)
     |> :binary.decode_unsigned()
     |> rem(50)
+  end
+
+  defp join_game(player_name, %{assigns: assigns} = socket) do
+    player_name =
+      player_name
+      |> HtmlSanitizeEx.strip_tags()
+      |> sanitize_player_name()
+
+    player_id = Ecto.UUID.generate()
+    :ok = MultiplayerEngine.join(player_id, player_name)
+
+    # Update the shared game dimensions to match this player's viewport
+    MultiplayerEngine.update_viewport(assigns.zoom_level, assigns.game_width, assigns.game_height)
+
+    socket
+    |> assign(:joined, true)
+    |> assign(:dead, false)
+    |> assign(:player_id, player_id)
+    |> assign(:player_name, player_name)
+    |> assign(:last_bird_standing, false)
   end
 
   defp sanitize_player_name(player_name) do

--- a/lib/flappy_web/live/flappy_multiplayer_live.ex
+++ b/lib/flappy_web/live/flappy_multiplayer_live.ex
@@ -1,0 +1,394 @@
+defmodule FlappyWeb.FlappyMultiplayerLive do
+  @moduledoc """
+  Multiplayer game LiveView. Connects to the global MultiplayerEngine.
+  """
+  use FlappyWeb, :live_view
+
+  alias Flappy.MultiplayerEngine
+  alias Flappy.GameState
+  alias Flappy.Position
+
+  def render(assigns) do
+    ~H"""
+    <div>
+      <%!-- Name entry screen --%>
+      <div
+        :if={!@joined}
+        class="flex flex-col items-center justify-center h-screen"
+      >
+        <p class="text-white text-4xl my-11">Multiplayer: King of the Hill</p>
+
+        <div class="space-y-2">
+          <p class="text-white text-2xl text-center">Compete in a shared world!</p>
+          <p class="text-white text-xl text-center">Survive the longest to wear the crown</p>
+        </div>
+
+        <.simple_form for={@name_form} phx-submit="join_game" class="flex flex-col items-center">
+          <div class="relative">
+            <.input
+              type="text"
+              value=""
+              name="player_name"
+              placeholder="Enter your name"
+              class="rounded-l-md border-r-0 focus:outline-none focus:ring-2 focus:ring-purple-500"
+              maxlength="10"
+              required
+            />
+          </div>
+
+          <.button type="submit" class="bg-purple-600 rounded">
+            <p class="text-4xl text-white">Join Game</p>
+          </.button>
+        </.simple_form>
+
+        <.back navigate={~p"/"}>
+          <p class="text-lg text-cyan-100 hover:text-fuchsia-500">Back to Singleplayer</p>
+        </.back>
+      </div>
+
+      <%!-- Death screen overlay --%>
+      <div
+        :if={@joined && @dead}
+        class="fixed inset-0 flex flex-col items-center justify-center z-50 bg-black bg-opacity-70"
+      >
+        <p class="text-red-400 text-5xl font-bold mb-4">YOU DIED</p>
+        <p class="text-white text-2xl mb-2">
+          Survival time: {format_survival_time(@my_survival_time)}
+        </p>
+        <p class="text-white text-xl mb-6">Score: {@my_score}</p>
+
+        <.button phx-click="rejoin" class="bg-purple-600 text-white px-6 py-3 rounded text-2xl">
+          Rejoin
+        </.button>
+
+        <div class="mt-4">
+          <.back navigate={~p"/"}>
+            <p class="text-lg text-cyan-100 hover:text-fuchsia-500">Back to Menu</p>
+          </.back>
+        </div>
+      </div>
+
+      <%!-- LAST BIRD STANDING banner --%>
+      <div
+        :if={@last_bird_standing}
+        class="fixed top-1/4 left-0 right-0 z-50 flex justify-center pointer-events-none"
+      >
+        <div class="animate-pulse">
+          <p class="text-yellow-300 text-6xl font-bold text-center"
+             style="text-shadow: 0 0 20px rgba(234, 179, 8, 0.8), 0 0 40px rgba(234, 179, 8, 0.4);">
+            LAST BIRD STANDING
+          </p>
+        </div>
+      </div>
+
+      <%!-- Multiplayer HUD --%>
+      <div :if={@joined} class="fixed top-0 left-0 right-0 z-50 flex justify-between p-4 pointer-events-none">
+        <%!-- Left: my score + survival time --%>
+        <div class="bg-black bg-opacity-70 rounded-md p-3">
+          <p class="text-white text-2xl">Score: {@my_score}</p>
+          <p class="text-gray-300 text-lg">Time: {format_survival_time(@my_survival_time)}</p>
+        </div>
+
+        <%!-- Center: crown holder --%>
+        <div class="bg-black bg-opacity-70 rounded-md p-3 text-center">
+          <div :if={@crown_holder_name} class="flex items-center justify-center gap-2">
+            <svg class="w-8 h-8 text-yellow-400" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z"/>
+            </svg>
+            <p class="text-yellow-300 text-2xl font-bold">{@crown_holder_name}</p>
+          </div>
+          <p :if={@crown_holder_name} class="text-gray-300 text-sm">
+            {format_survival_time(@crown_holder_time)}
+          </p>
+          <p :if={!@crown_holder_name} class="text-gray-400 text-lg">No crown holder</p>
+        </div>
+
+        <%!-- Right: player count --%>
+        <div class="bg-black bg-opacity-70 rounded-md p-3 text-right">
+          <p class="text-white text-2xl">{@alive_count} alive</p>
+          <p class="text-gray-300 text-lg">{@total_count} total</p>
+        </div>
+      </div>
+
+      <%!-- Game Area --%>
+      <div id="game-area" phx-hook="ResizeHook" class="game-area w-screen h-screen -z-0">
+        <%!-- All players --%>
+        <%= if @joined do %>
+          <%= for {pid, player} <- @game_state.players, Map.get(player, :alive, true) do %>
+            <div
+              id={"player-#{pid}"}
+              phx-window-keydown={if pid == @player_id, do: "player_action", else: nil}
+              style={"position: absolute; left: #{elem(player.position, 2)}%; top: #{elem(player.position, 3)}%;"}
+            >
+              <%!-- Name tag --%>
+              <div class="absolute -top-6 left-1/2 -translate-x-1/2 whitespace-nowrap">
+                <span class={"text-sm font-bold px-1 rounded #{if pid == @player_id, do: "text-yellow-300 bg-black bg-opacity-60", else: "text-white bg-black bg-opacity-40"}"}>
+                  {player.name}
+                </span>
+              </div>
+
+              <%!-- Crown indicator --%>
+              <div :if={pid == @crown_holder_id} class="absolute -top-10 left-1/2 -translate-x-1/2">
+                <svg class="w-6 h-6 text-yellow-400 animate-bounce" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z"/>
+                </svg>
+              </div>
+
+              <%!-- Bird sprite --%>
+              <img
+                src={player.sprite.image}
+                class={bird_class(pid, @player_id, player)}
+              />
+            </div>
+
+            <%!-- Laser beam for this player --%>
+            <div
+              :if={player.laser_beam}
+              id={"laser-#{pid}"}
+              class="absolute bg-red-900 h-1 rounded-md"
+              style={"left: #{Position.bird_x_eye_position(player, @game_state.game_width)}%; top: #{Position.bird_y_eye_position(player, @game_state.game_height)}%; width: #{100 - elem(player.position, 2)}%;"}
+            >
+            </div>
+          <% end %>
+        <% end %>
+
+        <%!-- Enemies --%>
+        <%= for %{position: {_, _, x_pos, y_pos}} = enemy <- @game_state.enemies do %>
+          <div
+            id={"enemy-container-#{enemy.id}"}
+            style={"position: absolute; left: #{x_pos}%; top: #{y_pos}%; z-index: #{calculate_z_index(enemy.id)};"}
+          >
+            <img src={enemy.sprite.image} />
+          </div>
+        <% end %>
+
+        <%!-- Power Ups --%>
+        <%= for %{position: {_, _, x_pos, y_pos}} = power_up <- @game_state.power_ups do %>
+          <div
+            id={"power-up-container-#{power_up.id}"}
+            class="absolute"
+            style={"position: absolute; left: #{x_pos}%; top: #{y_pos}%;"}
+          >
+            <img src={power_up.sprite.image} />
+          </div>
+        <% end %>
+
+        <%!-- Explosions --%>
+        <%= for %{position: {_, _, x_pos, y_pos}} = explosion <- @game_state.explosions do %>
+          <div
+            id={"explosion-container-#{explosion.id}"}
+            class="explosion"
+            style={"position: absolute; left: #{x_pos}%; top: #{y_pos}%;"}
+          >
+            <img src={explosion.sprite.image} />
+          </div>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  def mount(_params, _session, socket) do
+    game_height = get_connect_params(socket)["viewport_height"] || 760
+    game_width = get_connect_params(socket)["viewport_width"] || 1440
+    zoom_level = get_connect_params(socket)["zoom_level"] || 2
+
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Flappy.PubSub, MultiplayerEngine.pubsub_topic())
+    end
+
+    {:ok,
+     socket
+     |> assign(:name_form, to_form(%{}))
+     |> assign(:joined, false)
+     |> assign(:dead, false)
+     |> assign(:player_id, nil)
+     |> assign(:player_name, "")
+     |> assign(:game_state, %GameState{})
+     |> assign(:my_score, 0)
+     |> assign(:my_survival_time, 0)
+     |> assign(:crown_holder_id, nil)
+     |> assign(:crown_holder_name, nil)
+     |> assign(:crown_holder_time, 0)
+     |> assign(:alive_count, 0)
+     |> assign(:total_count, 0)
+     |> assign(:last_bird_standing, false)
+     |> assign(:game_height, game_height)
+     |> assign(:game_width, game_width)
+     |> assign(:zoom_level, zoom_level)}
+  end
+
+  def terminate(_reason, %{assigns: %{joined: true, player_id: player_id}} = _socket) do
+    MultiplayerEngine.leave(player_id)
+    :ok
+  end
+
+  def terminate(_reason, _socket), do: :ok
+
+  def handle_event("join_game", %{"player_name" => player_name}, socket) do
+    if String.length(player_name) in 1..10 do
+      player_name =
+        player_name
+        |> HtmlSanitizeEx.strip_tags()
+        |> sanitize_player_name()
+
+      player_id = Ecto.UUID.generate()
+      :ok = MultiplayerEngine.join(player_id, player_name)
+
+      {:noreply,
+       socket
+       |> assign(:joined, true)
+       |> assign(:dead, false)
+       |> assign(:player_id, player_id)
+       |> assign(:player_name, player_name)}
+    else
+      {:noreply, put_flash(socket, :error, "Name must be between 1 and 10 characters")}
+    end
+  end
+
+  def handle_event("rejoin", _, %{assigns: %{player_name: player_name}} = socket) do
+    player_id = Ecto.UUID.generate()
+    :ok = MultiplayerEngine.join(player_id, player_name)
+
+    {:noreply,
+     socket
+     |> assign(:dead, false)
+     |> assign(:player_id, player_id)
+     |> assign(:last_bird_standing, false)}
+  end
+
+  def handle_event(
+        "player_action",
+        %{"key" => key},
+        %{assigns: %{player_id: player_id, dead: false}} = socket
+      ) do
+    action =
+      case String.downcase(key) do
+        key when key in ["arrowup", "w"] -> :go_up
+        key when key in ["arrowdown", "s"] -> :go_down
+        key when key in ["arrowright", "d"] -> :go_right
+        key when key in ["arrowleft", "a"] -> :go_left
+        " " -> :fire_laser
+        _key -> nil
+      end
+
+    if action do
+      MultiplayerEngine.player_input(player_id, action)
+    end
+
+    {:noreply, socket}
+  end
+
+  def handle_event("player_action", _, socket), do: {:noreply, socket}
+
+  def handle_event("resize", %{"height" => h, "width" => w, "zoom" => z}, socket) do
+    MultiplayerEngine.update_viewport(z, w, h)
+    {:noreply, assign(socket, game_width: w, game_height: h, zoom_level: z)}
+  end
+
+  def handle_info({:multiplayer_state, game_state}, %{assigns: assigns} = socket) do
+    player_id = assigns.player_id
+    my_player = game_state.players[player_id]
+
+    # Check if I just died
+    just_died = my_player != nil && !Map.get(my_player, :alive, true) && !assigns.dead
+
+    # Derive HUD data
+    crown_id = GameState.crown_holder(game_state)
+    crown_player = if crown_id, do: game_state.players[crown_id]
+
+    alive_players = Enum.filter(game_state.players, fn {_id, p} -> Map.get(p, :alive, true) end)
+
+    is_last_bird =
+      my_player != nil &&
+        Map.get(my_player, :alive, true) &&
+        GameState.last_bird_standing?(game_state)
+
+    socket =
+      socket
+      |> assign(:game_state, game_state)
+      |> assign(:my_score, if(my_player, do: my_player.score, else: assigns.my_score))
+      |> assign(:my_survival_time, if(my_player, do: Map.get(my_player, :survival_time, 0), else: assigns.my_survival_time))
+      |> assign(:crown_holder_id, crown_id)
+      |> assign(:crown_holder_name, if(crown_player, do: crown_player.name, else: nil))
+      |> assign(:crown_holder_time, if(crown_player, do: Map.get(crown_player, :survival_time, 0), else: 0))
+      |> assign(:alive_count, length(alive_players))
+      |> assign(:total_count, map_size(game_state.players))
+      |> assign(:last_bird_standing, is_last_bird)
+
+    socket = if just_died, do: assign(socket, :dead, true), else: socket
+
+    {:noreply, socket}
+  end
+
+  # --- Helpers ---
+
+  defp bird_class(pid, my_id, player) do
+    base = ""
+
+    # Golden highlight for self
+    self_glow =
+      if pid == my_id,
+        do: "filter drop-shadow-[0_0_15px_rgba(255,215,0,0.8)]",
+        else: ""
+
+    # Laser glow
+    laser_glow =
+      if player.laser_allowed,
+        do: "filter drop-shadow-[0_5px_10px_rgba(255,0,0,0.7)]",
+        else: ""
+
+    # Self highlight takes priority, laser glow as fallback
+    cond do
+      pid == my_id && player.laser_allowed ->
+        "filter drop-shadow-[0_0_15px_rgba(255,215,0,0.8)] drop-shadow-[0_5px_10px_rgba(255,0,0,0.7)]"
+
+      pid == my_id ->
+        self_glow
+
+      player.laser_allowed ->
+        laser_glow
+
+      true ->
+        base
+    end
+  end
+
+  defp format_survival_time(ticks) when is_integer(ticks) do
+    seconds = ticks
+    minutes = div(seconds, 60)
+    secs = rem(seconds, 60)
+
+    if minutes > 0 do
+      "#{minutes}m #{String.pad_leading(Integer.to_string(secs), 2, "0")}s"
+    else
+      "#{secs}s"
+    end
+  end
+
+  defp format_survival_time(_), do: "0s"
+
+  defp calculate_z_index(""), do: 50
+
+  defp calculate_z_index(uuid) do
+    uuid
+    |> binary_part(0, 2)
+    |> :binary.decode_unsigned()
+    |> rem(50)
+  end
+
+  defp sanitize_player_name(player_name) do
+    config = Expletive.configure(blacklist: Expletive.Blacklist.english())
+
+    player_name =
+      player_name
+      |> HtmlSanitizeEx.strip_tags()
+      |> Expletive.sanitize(config)
+
+    if player_name |> String.replace(" ", "") |> Expletive.profane?(config) do
+      "Anonymous"
+    else
+      player_name
+    end
+  end
+end

--- a/lib/flappy_web/live/flappy_scores.ex
+++ b/lib/flappy_web/live/flappy_scores.ex
@@ -34,8 +34,8 @@ defmodule FlappyWeb.FlappyLiveScores do
             </button>
           </div>
 
-          <%!-- Version selector (singleplayer only) --%>
-          <div :if={@mode == "singleplayer"}>
+          <%!-- Version selector --%>
+          <div>
             <h1 class="text-cyan-100">Version</h1>
 
             <.simple_form for={@form} phx-change="version_selected">
@@ -100,8 +100,8 @@ defmodule FlappyWeb.FlappyLiveScores do
     {:noreply, push_patch(socket, to: ~p"/highscores?mode=#{mode}")}
   end
 
-  def handle_event("version_selected", %{"version" => version}, socket) do
-    {:noreply, push_patch(socket, to: ~p"/highscores?version=#{version}&mode=singleplayer")}
+  def handle_event("version_selected", %{"version" => version}, %{assigns: %{mode: mode}} = socket) do
+    {:noreply, push_patch(socket, to: ~p"/highscores?version=#{version}&mode=#{mode}")}
   end
 
   def handle_params(params, _uri, socket) do
@@ -114,7 +114,7 @@ defmodule FlappyWeb.FlappyLiveScores do
     socket =
       case mode do
         "multiplayer" ->
-          mp_scores = MultiplayerScores.get_leaderboard(100)
+          mp_scores = MultiplayerScores.get_leaderboard(100, version)
           assign(socket, :mp_scores, mp_scores)
 
         _ ->

--- a/lib/flappy_web/live/flappy_scores.ex
+++ b/lib/flappy_web/live/flappy_scores.ex
@@ -3,6 +3,7 @@ defmodule FlappyWeb.FlappyLiveScores do
   use FlappyWeb, :live_view
 
   alias Flappy.Players
+  alias Flappy.MultiplayerScores
 
   def render(assigns) do
     ~H"""
@@ -14,31 +15,68 @@ defmodule FlappyWeb.FlappyLiveScores do
           <p class="text-lg text-cyan-100 hover:text-fuchsia-500">Back to Game</p>
         </.back>
 
-        <div>
-          <h1 class="text-cyan-100">Version</h1>
+        <div class="flex flex-row gap-4 items-end">
+          <%!-- Mode tabs --%>
+          <div class="flex gap-2">
+            <button
+              phx-click="set_mode"
+              phx-value-mode="singleplayer"
+              class={"px-4 py-2 rounded-t text-lg font-bold #{if @mode == "singleplayer", do: "bg-blue-600 text-white", else: "bg-gray-700 text-gray-300 hover:bg-gray-600"}"}
+            >
+              Singleplayer
+            </button>
+            <button
+              phx-click="set_mode"
+              phx-value-mode="multiplayer"
+              class={"px-4 py-2 rounded-t text-lg font-bold #{if @mode == "multiplayer", do: "bg-purple-600 text-white", else: "bg-gray-700 text-gray-300 hover:bg-gray-600"}"}
+            >
+              Multiplayer
+            </button>
+          </div>
 
-          <.simple_form for={@form} phx-change="version_selected">
-            <.input
-              class="w-2/12"
-              type="select"
-              name="version"
-              options={@available_versions}
-              value={@version}
-            />
-          </.simple_form>
+          <%!-- Version selector (singleplayer only) --%>
+          <div :if={@mode == "singleplayer"}>
+            <h1 class="text-cyan-100">Version</h1>
+
+            <.simple_form for={@form} phx-change="version_selected">
+              <.input
+                class="w-2/12"
+                type="select"
+                name="version"
+                options={@available_versions}
+                value={@version}
+              />
+            </.simple_form>
+          </div>
         </div>
       </div>
 
       <div class="scrollable-content">
-        <.table id="players" rows={@players}>
-          <:col :let={player} label="Name">
-            <p class="text-cyan-100">{player.name}</p>
-          </:col>
+        <%!-- Singleplayer table --%>
+        <div :if={@mode == "singleplayer"}>
+          <.table id="players" rows={@players}>
+            <:col :let={player} label="Name">
+              <p class="text-cyan-100">{player.name}</p>
+            </:col>
 
-          <:col :let={player} label="Score">
-            <p class="text-cyan-100">{player.score}</p>
-          </:col>
-        </.table>
+            <:col :let={player} label="Score">
+              <p class="text-cyan-100">{player.score}</p>
+            </:col>
+          </.table>
+        </div>
+
+        <%!-- Multiplayer table --%>
+        <div :if={@mode == "multiplayer"}>
+          <.table id="mp-scores" rows={@mp_scores}>
+            <:col :let={score} label="Name">
+              <p class="text-cyan-100">{score.name}</p>
+            </:col>
+
+            <:col :let={score} label="Survival Time">
+              <p class="text-cyan-100">{format_survival_time(score.survival_time_ms)}</p>
+            </:col>
+          </.table>
+        </div>
       </div>
     </div>
     """
@@ -52,32 +90,56 @@ defmodule FlappyWeb.FlappyLiveScores do
      socket
      |> assign(:form, to_form(%{}))
      |> assign(:available_versions, available_versions)
-     |> assign(:version, version)}
+     |> assign(:version, version)
+     |> assign(:mode, "singleplayer")
+     |> assign(:players, [])
+     |> assign(:mp_scores, [])}
+  end
+
+  def handle_event("set_mode", %{"mode" => mode}, socket) do
+    {:noreply, push_patch(socket, to: ~p"/highscores?mode=#{mode}")}
   end
 
   def handle_event("version_selected", %{"version" => version}, socket) do
-    {:noreply, push_patch(socket, to: ~p"/highscores?version=#{version}")}
+    {:noreply, push_patch(socket, to: ~p"/highscores?version=#{version}&mode=singleplayer")}
   end
 
-  def handle_params(%{"version" => version}, _uri, socket) do
-    limit = 100
+  def handle_params(params, _uri, socket) do
+    mode = params["mode"] || "singleplayer"
+    version = params["version"] || Application.get_env(:flappy, :game_version, "1")
 
-    players =
-      limit
-      |> Players.get_current_high_scores(version)
-      |> Enum.map(fn {name, score} -> %{name: name, score: score} end)
+    socket = assign(socket, :mode, mode)
+    socket = assign(socket, :version, version)
 
-    {:noreply, socket |> assign(:players, players) |> assign(:version, version)}
+    socket =
+      case mode do
+        "multiplayer" ->
+          mp_scores = MultiplayerScores.get_leaderboard(100)
+          assign(socket, :mp_scores, mp_scores)
+
+        _ ->
+          players =
+            100
+            |> Players.get_current_high_scores(version)
+            |> Enum.map(fn {name, score} -> %{name: name, score: score} end)
+
+          assign(socket, :players, players)
+      end
+
+    {:noreply, socket}
   end
 
-  def handle_params(_params, _uri, socket) do
-    version = Application.get_env(:flappy, :game_version, "1")
+  defp format_survival_time(ms) when is_integer(ms) do
+    total_seconds = div(ms, 1000)
+    minutes = div(total_seconds, 60)
+    secs = rem(total_seconds, 60)
 
-    players =
-      100
-      |> Players.get_current_high_scores(version)
-      |> Enum.map(fn {name, score} -> %{name: name, score: score} end)
-
-    {:noreply, socket |> assign(:players, players) |> assign(:version, version)}
+    if minutes > 0 do
+      "#{minutes}m #{String.pad_leading(Integer.to_string(secs), 2, "0")}s"
+    else
+      "#{secs}s"
+    end
   end
+
+  defp format_survival_time(_), do: "0s"
 end

--- a/lib/flappy_web/router.ex
+++ b/lib/flappy_web/router.ex
@@ -25,6 +25,7 @@ defmodule FlappyWeb.Router do
     pipe_through :browser
 
     live "/", FlappyLive
+    live "/multiplayer", FlappyMultiplayerLive
     live "/highscores", FlappyLiveScores
   end
 

--- a/priv/repo/migrations/20260324040937_add_multiplayer_scores_table.exs
+++ b/priv/repo/migrations/20260324040937_add_multiplayer_scores_table.exs
@@ -1,0 +1,14 @@
+defmodule Flappy.Repo.Migrations.AddMultiplayerScoresTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:multiplayer_scores) do
+      add :name, :string, null: false
+      add :survival_time_ms, :integer, null: false
+
+      timestamps()
+    end
+
+    create index(:multiplayer_scores, [:survival_time_ms])
+  end
+end

--- a/priv/repo/migrations/20260324155501_add_version_to_multiplayer_scores.exs
+++ b/priv/repo/migrations/20260324155501_add_version_to_multiplayer_scores.exs
@@ -1,0 +1,9 @@
+defmodule Flappy.Repo.Migrations.AddVersionToMultiplayerScores do
+  use Ecto.Migration
+
+  def change do
+    alter table(:multiplayer_scores) do
+      add :version, :integer
+    end
+  end
+end

--- a/test/flappy/game_state_test.exs
+++ b/test/flappy/game_state_test.exs
@@ -3,6 +3,8 @@ defmodule Flappy.GameStateTest do
 
   alias Flappy.GameState
 
+  @player_id "test-player"
+
   describe "new/0" do
     test "creates a valid default game state struct" do
       state = GameState.new()
@@ -12,8 +14,10 @@ defmodule Flappy.GameStateTest do
       assert state.enemies == []
       assert state.power_ups == []
       assert state.explosions == []
-      assert state.player.position != nil
-      assert state.player.velocity == {0.0, 0.0}
+      assert map_size(state.players) == 1
+      player = first_player(state)
+      assert player.position != nil
+      assert player.velocity == {0.0, 0.0}
       assert state.gravity > 0
       assert state.game_height > 0
       assert state.game_width > 0
@@ -29,77 +33,80 @@ defmodule Flappy.GameStateTest do
     test "accepts player overrides merged into defaults" do
       state = GameState.new(player: %{laser_allowed: true, score: 42})
 
-      assert state.player.laser_allowed == true
-      assert state.player.score == 42
+      player = first_player(state)
+      assert player.laser_allowed == true
+      assert player.score == 42
       # defaults preserved
-      assert state.player.velocity == {0.0, 0.0}
-      assert state.player.invincibility == false
+      assert player.velocity == {0.0, 0.0}
+      assert player.invincibility == false
     end
   end
 
-  describe "handle_input/2" do
+  describe "handle_input/3" do
     test "go_up decreases y velocity (thrust upward)" do
-      state = GameState.new()
-      {_vx, initial_vy} = state.player.velocity
+      state = GameState.new(player_id: @player_id)
+      {_vx, initial_vy} = first_player(state).velocity
 
-      new_state = GameState.handle_input(state, :go_up)
+      new_state = GameState.handle_input(state, @player_id, :go_up)
 
-      {_vx, new_vy} = new_state.player.velocity
+      {_vx, new_vy} = first_player(new_state).velocity
       assert new_vy < initial_vy, "y velocity should decrease (move up)"
     end
 
     test "go_down increases y velocity (thrust downward)" do
-      state = GameState.new()
-      {_vx, initial_vy} = state.player.velocity
+      state = GameState.new(player_id: @player_id)
+      {_vx, initial_vy} = first_player(state).velocity
 
-      new_state = GameState.handle_input(state, :go_down)
+      new_state = GameState.handle_input(state, @player_id, :go_down)
 
-      {_vx, new_vy} = new_state.player.velocity
+      {_vx, new_vy} = first_player(new_state).velocity
       assert new_vy > initial_vy, "y velocity should increase (move down)"
     end
 
     test "go_right increases x velocity" do
-      state = GameState.new()
-      {initial_vx, _vy} = state.player.velocity
+      state = GameState.new(player_id: @player_id)
+      {initial_vx, _vy} = first_player(state).velocity
 
-      new_state = GameState.handle_input(state, :go_right)
+      new_state = GameState.handle_input(state, @player_id, :go_right)
 
-      {new_vx, _vy} = new_state.player.velocity
+      {new_vx, _vy} = first_player(new_state).velocity
       assert new_vx > initial_vx, "x velocity should increase (move right)"
     end
 
     test "go_left decreases x velocity" do
-      state = GameState.new()
-      {initial_vx, _vy} = state.player.velocity
+      state = GameState.new(player_id: @player_id)
+      {initial_vx, _vy} = first_player(state).velocity
 
-      new_state = GameState.handle_input(state, :go_left)
+      new_state = GameState.handle_input(state, @player_id, :go_left)
 
-      {new_vx, _vy} = new_state.player.velocity
+      {new_vx, _vy} = first_player(new_state).velocity
       assert new_vx < initial_vx, "x velocity should decrease (move left)"
     end
 
     test "fire_laser activates laser when laser_allowed" do
-      state = GameState.new(player: %{laser_allowed: true})
+      state = GameState.new(player_id: @player_id, player: %{laser_allowed: true})
 
-      new_state = GameState.handle_input(state, :fire_laser)
+      new_state = GameState.handle_input(state, @player_id, :fire_laser)
 
-      assert new_state.player.laser_beam == true
-      assert new_state.player.laser_duration == 3
+      player = first_player(new_state)
+      assert player.laser_beam == true
+      assert player.laser_duration == 3
     end
 
     test "fire_laser is a no-op when laser not allowed" do
-      state = GameState.new(player: %{laser_allowed: false})
+      state = GameState.new(player_id: @player_id, player: %{laser_allowed: false})
 
-      new_state = GameState.handle_input(state, :fire_laser)
+      new_state = GameState.handle_input(state, @player_id, :fire_laser)
 
-      assert new_state.player.laser_beam == false
-      assert new_state.player.laser_duration == 0
+      player = first_player(new_state)
+      assert player.laser_beam == false
+      assert player.laser_duration == 0
     end
 
     test "update_viewport changes dimensions and zoom" do
-      state = GameState.new()
+      state = GameState.new(player_id: @player_id)
 
-      new_state = GameState.handle_input(state, {:update_viewport, 2.0, 1920, 1080})
+      new_state = GameState.handle_input(state, @player_id, {:update_viewport, 2.0, 1920, 1080})
 
       assert new_state.zoom_level == 2.0
       assert new_state.game_width == 1920
@@ -119,21 +126,33 @@ defmodule Flappy.GameStateTest do
       score_multiplier: 10,
       difficulty_score: 400,
       game_over: false,
-      player: %{
-        position: {100.0, 300.0, 12.5, 50.0},
-        velocity: {0.0, 0.0},
-        sprite: %{image: "/images/phoenix.svg", size: {50, 50}, name: :phoenix},
-        score: 0,
-        granted_powers: [],
-        laser_allowed: false,
-        laser_beam: false,
-        laser_duration: 0,
-        invincibility: false
+      players: %{
+        @player_id => %{
+          position: {100.0, 300.0, 12.5, 50.0},
+          velocity: {0.0, 0.0},
+          sprite: %{image: "/images/phoenix.svg", size: {50, 50}, name: :phoenix},
+          score: 0,
+          granted_powers: [],
+          laser_allowed: false,
+          laser_beam: false,
+          laser_duration: 0,
+          invincibility: false,
+          hitbox: nil,
+          alive: true,
+          name: "Test",
+          survival_time: 0
+        }
       },
       enemies: [],
       power_ups: [],
-      explosions: []
+      explosions: [],
+      deaths_this_tick: []
     }
+  end
+
+  defp first_player(%{players: players}) do
+    {_id, player} = Enum.at(players, 0)
+    player
   end
 
   describe "tick/1 player physics" do
@@ -141,20 +160,20 @@ defmodule Flappy.GameStateTest do
       state = base_state()
       {:ok, new_state} = GameState.tick(state)
 
-      {_x_vel, y_vel} = new_state.player.velocity
+      {_x_vel, y_vel} = first_player(new_state).velocity
       # gravity=175, tick=15ms -> delta = 175 * 0.015 = 2.625
       assert y_vel > 0, "gravity should increase y velocity downward"
     end
 
     test "updates player position based on velocity" do
       state = base_state()
-      player = %{state.player | velocity: {10.0, 20.0}}
-      state = %{state | player: player}
+      player = %{state.players[@player_id] | velocity: {10.0, 20.0}}
+      state = %{state | players: %{@player_id => player}}
 
       {:ok, new_state} = GameState.tick(state)
 
-      {new_x, new_y, _xp, _yp} = new_state.player.position
-      {orig_x, orig_y, _xp, _yp} = state.player.position
+      {new_x, new_y, _xp, _yp} = first_player(new_state).position
+      {orig_x, orig_y, _xp, _yp} = player.position
 
       assert new_x > orig_x, "player should move right with positive x velocity"
       assert new_y > orig_y, "player should move down with positive y velocity"
@@ -254,7 +273,7 @@ defmodule Flappy.GameStateTest do
     test "returns game_over when player collides with enemy (no invincibility)" do
       state = base_state()
       # Place enemy right on top of player
-      {px, py, pxp, pyp} = state.player.position
+      {px, py, pxp, pyp} = state.players[@player_id].position
 
       enemy = %Flappy.Enemy{
         position: {px, py, pxp, pyp},
@@ -271,7 +290,7 @@ defmodule Flappy.GameStateTest do
 
     test "with invincibility, destroys enemies instead of game over" do
       state = base_state()
-      {px, py, pxp, pyp} = state.player.position
+      {px, py, pxp, pyp} = state.players[@player_id].position
 
       enemy = %Flappy.Enemy{
         position: {px, py, pxp, pyp},
@@ -280,8 +299,8 @@ defmodule Flappy.GameStateTest do
         id: "enemy-collide"
       }
 
-      player = %{state.player | invincibility: true, granted_powers: [{:invincibility, 5}]}
-      state = %{state | enemies: [enemy], player: player}
+      player = %{state.players[@player_id] | invincibility: true, granted_powers: [{:invincibility, 5}]}
+      state = %{state | enemies: [enemy], players: %{@player_id => player}}
 
       assert {:ok, new_state} = GameState.tick(state)
       assert new_state.game_over == false
@@ -294,8 +313,8 @@ defmodule Flappy.GameStateTest do
   describe "tick/1 out of bounds" do
     test "game over when player goes above screen" do
       state = base_state()
-      player = %{state.player | position: {100.0, -50.0, 12.5, -8.3}}
-      state = %{state | player: player}
+      player = %{state.players[@player_id] | position: {100.0, -50.0, 12.5, -8.3}}
+      state = %{state | players: %{@player_id => player}}
 
       assert {:game_over, new_state} = GameState.tick(state)
       assert new_state.game_over == true
@@ -304,8 +323,8 @@ defmodule Flappy.GameStateTest do
     test "game over when player falls below screen" do
       state = base_state()
       # y% > 100 - sprite_height_percent
-      player = %{state.player | position: {100.0, 590.0, 12.5, 98.0}}
-      state = %{state | player: player}
+      player = %{state.players[@player_id] | position: {100.0, 590.0, 12.5, 98.0}}
+      state = %{state | players: %{@player_id => player}}
 
       assert {:game_over, new_state} = GameState.tick(state)
       assert new_state.game_over == true
@@ -313,8 +332,8 @@ defmodule Flappy.GameStateTest do
 
     test "game over when player goes off right side" do
       state = base_state()
-      player = %{state.player | position: {850.0, 300.0, 106.0, 50.0}}
-      state = %{state | player: player}
+      player = %{state.players[@player_id] | position: {850.0, 300.0, 106.0, 50.0}}
+      state = %{state | players: %{@player_id => player}}
 
       assert {:game_over, new_state} = GameState.tick(state)
       assert new_state.game_over == true
@@ -324,8 +343,8 @@ defmodule Flappy.GameStateTest do
       state = base_state()
       # After tick, sprite may be resized by grant_power_ups (128px wide).
       # Threshold: 0 - 128/800*100 = -16%. Use x% well below that.
-      player = %{state.player | position: {-200.0, 300.0, -25.0, 50.0}}
-      state = %{state | player: player}
+      player = %{state.players[@player_id] | position: {-200.0, 300.0, -25.0, 50.0}}
+      state = %{state | players: %{@player_id => player}}
 
       assert {:game_over, new_state} = GameState.tick(state)
       assert new_state.game_over == true
@@ -337,7 +356,7 @@ defmodule Flappy.GameStateTest do
       state = base_state()
       # Player at left side, enemy to the right at same y-level
       player = %{
-        state.player
+        state.players[@player_id]
         | laser_beam: true,
           laser_duration: 3,
           laser_allowed: true,
@@ -346,7 +365,7 @@ defmodule Flappy.GameStateTest do
       }
 
       # Enemy at same y as player but to the right
-      {_px, py, _pxp, pyp} = state.player.position
+      {_px, py, _pxp, pyp} = player.position
 
       enemy = %Flappy.Enemy{
         position: {500.0, py, 62.5, pyp},
@@ -355,7 +374,7 @@ defmodule Flappy.GameStateTest do
         id: "enemy-laser-target"
       }
 
-      state = %{state | player: player, enemies: [enemy]}
+      state = %{state | players: %{@player_id => player}, enemies: [enemy]}
 
       {:ok, new_state} = GameState.tick(state)
 
@@ -368,7 +387,7 @@ defmodule Flappy.GameStateTest do
   describe "tick/1 power-up collection" do
     test "player collects power-up on contact and gains its effect" do
       state = base_state()
-      {px, py, pxp, pyp} = state.player.position
+      {px, py, pxp, pyp} = state.players[@player_id].position
 
       power_up = %Flappy.PowerUp{
         position: {px, py, pxp, pyp},
@@ -381,14 +400,15 @@ defmodule Flappy.GameStateTest do
 
       {:ok, new_state} = GameState.tick(state)
 
+      player = first_player(new_state)
       refute Enum.any?(new_state.power_ups, &(&1.id == "powerup-1"))
-      assert new_state.player.invincibility == true
-      assert {:invincibility, _duration} = List.keyfind(new_state.player.granted_powers, :invincibility, 0)
+      assert player.invincibility == true
+      assert {:invincibility, _duration} = List.keyfind(player.granted_powers, :invincibility, 0)
     end
 
     test "bomb power-up destroys all enemies and creates explosion" do
       state = base_state()
-      {px, py, pxp, pyp} = state.player.position
+      {px, py, pxp, pyp} = state.players[@player_id].position
 
       # Place bomb power-up on the player
       bomb = %Flappy.PowerUp{
@@ -423,7 +443,7 @@ defmodule Flappy.GameStateTest do
       # Should have explosion from the bomb
       assert length(new_state.explosions) > 0
       # Score should increase by enemies_killed * score_multiplier
-      assert new_state.player.score >= 2 * state.score_multiplier
+      assert first_player(new_state).score >= 2 * state.score_multiplier
     end
   end
 
@@ -432,38 +452,38 @@ defmodule Flappy.GameStateTest do
       state = base_state()
       new_state = GameState.score_tick(state)
 
-      assert new_state.player.score == 1
+      assert first_player(new_state).score == 1
     end
 
     test "decrements power-up durations and removes expired ones" do
       state = base_state()
-      player = %{state.player | granted_powers: [{:laser, 2}, {:invincibility, 0}]}
-      state = %{state | player: player}
+      player = %{state.players[@player_id] | granted_powers: [{:laser, 2}, {:invincibility, 0}]}
+      state = %{state | players: %{@player_id => player}}
 
       new_state = GameState.score_tick(state)
 
       # laser: 2->1 (kept), invincibility: 0->nil (removed)
-      assert new_state.player.granted_powers == [{:laser, 1}]
+      assert first_player(new_state).granted_powers == [{:laser, 1}]
     end
 
     test "may generate enemies on even score ticks" do
       state = base_state()
       # Score will become 1 (odd) — no enemy generation
-      player = %{state.player | score: 0}
-      state = %{state | player: player}
+      player = %{state.players[@player_id] | score: 0}
+      state = %{state | players: %{@player_id => player}}
 
       new_state = GameState.score_tick(state)
       # Score is now 1 (odd), so no enemy generation triggered
-      assert new_state.player.score == 1
+      assert first_player(new_state).score == 1
       assert new_state.enemies == []
     end
 
     test "triggers enemy generation check on even score" do
       state = base_state()
       # Score will become 2 (even) — enemy generation attempted
-      player = %{state.player | score: 1}
+      player = %{state.players[@player_id] | score: 1}
       # Set difficulty_score very low so generation is very likely
-      state = %{state | player: player, difficulty_score: 6}
+      state = %{state | players: %{@player_id => player}, difficulty_score: 6}
 
       # Run many times to statistically verify generation happens
       results =
@@ -478,12 +498,12 @@ defmodule Flappy.GameStateTest do
 
     test "generates power-ups on score divisible by 10" do
       state = base_state()
-      player = %{state.player | score: 9}
-      state = %{state | player: player}
+      player = %{state.players[@player_id] | score: 9}
+      state = %{state | players: %{@player_id => player}}
 
       new_state = GameState.score_tick(state)
 
-      assert new_state.player.score == 10
+      assert first_player(new_state).score == 10
       assert length(new_state.power_ups) == 1
     end
   end

--- a/test/flappy/hitbox_cache_test.exs
+++ b/test/flappy/hitbox_cache_test.exs
@@ -5,6 +5,7 @@ defmodule Flappy.HitboxCacheTest do
 
   @game_width 800
   @game_height 600
+  @player_id "test-player"
 
   describe "entity_hitbox/5" do
     test "returns a polygon for an angular entity" do
@@ -54,25 +55,27 @@ defmodule Flappy.HitboxCacheTest do
       player_hitbox = Hitbox.player_hitbox(12.5, 16.66, 50, 50, @game_width, @game_height)
       overlapping_hitbox = Hitbox.entity_hitbox(12.5, 16.66, 100, 100, @game_width, @game_height, :angular)
 
-      state = %{
-        game_width: @game_width,
-        game_height: @game_height,
-        player: %{
-          sprite: %{size: {50, 50}},
-          position: {100.0, 100.0, 12.5, 16.66},
-          hitbox: player_hitbox
-        },
-        enemies: [
-          %{
-            # Position says far away, but hitbox is overlapping player
-            position: {700.0, 500.0, 90.0, 90.0},
-            sprite: %{size: {100, 100}, name: :angular},
-            hitbox: overlapping_hitbox
-          }
-        ]
+      player = %{
+        sprite: %{size: {50, 50}},
+        position: {100.0, 100.0, 12.5, 16.66},
+        hitbox: player_hitbox
       }
 
-      result = Hitbox.check_for_enemy_collisions?(state)
+      enemies = [
+        %{
+          # Position says far away, but hitbox is overlapping player
+          position: {700.0, 500.0, 90.0, 90.0},
+          sprite: %{size: {100, 100}, name: :angular},
+          hitbox: overlapping_hitbox
+        }
+      ]
+
+      state = %{
+        game_width: @game_width,
+        game_height: @game_height
+      }
+
+      result = Hitbox.check_for_enemy_collisions(player, enemies, state)
       assert length(result) > 0, "should detect collision via cached hitbox, not recomputed from position"
     end
   end
@@ -97,16 +100,22 @@ defmodule Flappy.HitboxCacheTest do
         score_multiplier: 10,
         difficulty_score: 400,
         game_over: false,
-        player: %{
-          score: 0,
-          position: {100.0, 300.0, 12.5, 50.0},
-          velocity: {0, 0},
-          sprite: %{image: "/images/phoenix.svg", size: {50, 50}, name: :phoenix},
-          granted_powers: [],
-          laser_allowed: false,
-          laser_beam: false,
-          laser_duration: 0,
-          invincibility: false
+        players: %{
+          @player_id => %{
+            score: 0,
+            position: {100.0, 300.0, 12.5, 50.0},
+            velocity: {0, 0},
+            sprite: %{image: "/images/phoenix.svg", size: {50, 50}, name: :phoenix},
+            granted_powers: [],
+            laser_allowed: false,
+            laser_beam: false,
+            laser_duration: 0,
+            invincibility: false,
+            hitbox: nil,
+            alive: true,
+            name: "Test",
+            survival_time: 0
+          }
         },
         enemies: [enemy],
         power_ups: [],
@@ -138,16 +147,22 @@ defmodule Flappy.HitboxCacheTest do
         score_multiplier: 10,
         difficulty_score: 400,
         game_over: false,
-        player: %{
-          score: 0,
-          position: {100.0, 300.0, 12.5, 50.0},
-          velocity: {0, 0},
-          sprite: %{image: "/images/phoenix.svg", size: {50, 50}, name: :phoenix},
-          granted_powers: [],
-          laser_allowed: false,
-          laser_beam: false,
-          laser_duration: 0,
-          invincibility: false
+        players: %{
+          @player_id => %{
+            score: 0,
+            position: {100.0, 300.0, 12.5, 50.0},
+            velocity: {0, 0},
+            sprite: %{image: "/images/phoenix.svg", size: {50, 50}, name: :phoenix},
+            granted_powers: [],
+            laser_allowed: false,
+            laser_beam: false,
+            laser_duration: 0,
+            invincibility: false,
+            hitbox: nil,
+            alive: true,
+            name: "Test",
+            survival_time: 0
+          }
         },
         enemies: [],
         power_ups: [power_up],
@@ -161,7 +176,7 @@ defmodule Flappy.HitboxCacheTest do
       assert %Polygons.Polygon{} = updated_pu.hitbox
     end
 
-    test "Player.update_player attaches hitbox to player" do
+    test "Player.update_players attaches hitbox to player" do
       state = %Flappy.GameState{
         game_id: "test",
         game_height: @game_height,
@@ -173,25 +188,32 @@ defmodule Flappy.HitboxCacheTest do
         score_multiplier: 10,
         difficulty_score: 400,
         game_over: false,
-        player: %{
-          score: 0,
-          position: {100.0, 300.0, 12.5, 50.0},
-          velocity: {0.0, 0.0},
-          sprite: %{image: "/images/phoenix.svg", size: {50, 50}, name: :phoenix},
-          granted_powers: [],
-          laser_allowed: false,
-          laser_beam: false,
-          laser_duration: 0,
-          invincibility: false
+        players: %{
+          @player_id => %{
+            score: 0,
+            position: {100.0, 300.0, 12.5, 50.0},
+            velocity: {0.0, 0.0},
+            sprite: %{image: "/images/phoenix.svg", size: {50, 50}, name: :phoenix},
+            granted_powers: [],
+            laser_allowed: false,
+            laser_beam: false,
+            laser_duration: 0,
+            invincibility: false,
+            hitbox: nil,
+            alive: true,
+            name: "Test",
+            survival_time: 0
+          }
         },
         enemies: [],
         power_ups: [],
         explosions: []
       }
 
-      new_state = Flappy.Players.Player.update_player(state)
+      new_state = Flappy.Players.Player.update_players(state)
 
-      assert %Polygons.Polygon{} = new_state.player.hitbox
+      player = new_state.players[@player_id]
+      assert %Polygons.Polygon{} = player.hitbox
     end
   end
 end

--- a/test/flappy/hitbox_test.exs
+++ b/test/flappy/hitbox_test.exs
@@ -3,120 +3,137 @@ defmodule Flappy.HitboxTest do
 
   alias Flappy.Hitbox
 
-  describe "get_hit_enemies/2" do
+  describe "get_hit_enemies/3" do
     test "detects collision with enemy" do
+      player = %{
+        sprite: %{size: {50, 50}},
+        position: {0, 0, 100, 100},
+        hitbox: nil
+      }
+
       game_state = %{
         game_width: 800,
-        game_height: 600,
-        player: %{
-          sprite: %{size: {50, 50}},
-          position: {0, 0, 100, 100}
-        }
+        game_height: 600
       }
 
       enemy = %{
         position: {0, 0, 100, 100},
-        sprite: %{size: {50, 50}, name: :angular}
+        sprite: %{size: {50, 50}, name: :angular},
+        hitbox: nil
       }
 
-      result = Hitbox.get_hit_enemies([enemy], game_state)
+      result = Hitbox.get_hit_enemies([enemy], player, game_state)
       assert length(result) > 0
     end
 
     test "returns empty list when no collisions" do
+      player = %{
+        sprite: %{size: {50, 50}},
+        position: {0, 0, 100, 100},
+        hitbox: nil
+      }
+
       game_state = %{
         game_width: 800,
-        game_height: 600,
-        player: %{
-          sprite: %{size: {50, 50}},
-          position: {0, 0, 100, 100}
-        }
+        game_height: 600
       }
 
       enemy = %{
         # Far away position
         position: {0, 0, 500, 500},
-        sprite: %{size: {50, 50}, name: :angular}
+        sprite: %{size: {50, 50}, name: :angular},
+        hitbox: nil
       }
 
-      result = Hitbox.get_hit_enemies([enemy], game_state)
+      result = Hitbox.get_hit_enemies([enemy], player, game_state)
       assert result == []
     end
   end
 
-  describe "get_hit_power_ups/2" do
+  describe "get_hit_power_ups/3" do
     test "detects collision with power up" do
+      player = %{
+        sprite: %{size: {50, 50}},
+        position: {0, 0, 100, 100},
+        hitbox: nil
+      }
+
       state = %{
         game_width: 800,
-        game_height: 600,
-        player: %{
-          sprite: %{size: {50, 50}},
-          position: {0, 0, 100, 100}
-        }
+        game_height: 600
       }
 
       power_up = %{
         position: {0, 0, 100, 100},
-        sprite: %{size: {30, 30}, name: :node}
+        sprite: %{size: {30, 30}, name: :node},
+        hitbox: nil
       }
 
-      result = Hitbox.get_hit_power_ups([power_up], state)
+      result = Hitbox.get_hit_power_ups([power_up], player, state)
       assert length(result) > 0
     end
   end
 
-  describe "get_hit_enemies/2 laser" do
+  describe "get_hit_enemies/3 laser" do
     test "laser hits enemy in its path" do
-      # Player at x=12.5%, y=50% on 800×600
+      # Player at x=12.5%, y=50% on 800x600
+      player = %{
+        sprite: %{size: {50, 50}},
+        position: {100.0, 300.0, 12.5, 50.0},
+        hitbox: nil
+      }
+
       game_state = %{
         game_width: 800,
-        game_height: 600,
-        player: %{
-          sprite: %{size: {50, 50}},
-          position: {100.0, 300.0, 12.5, 50.0}
-        }
+        game_height: 600
       }
 
       # Enemy placed ahead of the laser beam at ~30% x, same y height
       enemy = %{
         position: {240.0, 300.0, 30.0, 50.0},
-        sprite: %{size: {100, 100}, name: :angular}
+        sprite: %{size: {100, 100}, name: :angular},
+        hitbox: nil
       }
 
-      result = Hitbox.get_hit_enemies([enemy], game_state)
+      result = Hitbox.get_hit_enemies([enemy], player, game_state)
       assert length(result) > 0
     end
 
     test "laser does not hit enemy far above the beam" do
+      player = %{
+        sprite: %{size: {50, 50}},
+        position: {100.0, 300.0, 12.5, 50.0},
+        hitbox: nil
+      }
+
       game_state = %{
         game_width: 800,
-        game_height: 600,
-        player: %{
-          sprite: %{size: {50, 50}},
-          position: {100.0, 300.0, 12.5, 50.0}
-        }
+        game_height: 600
       }
 
       # Enemy far above the laser beam
       enemy = %{
         position: {240.0, 30.0, 30.0, 5.0},
-        sprite: %{size: {100, 100}, name: :angular}
+        sprite: %{size: {100, 100}, name: :angular},
+        hitbox: nil
       }
 
-      result = Hitbox.get_hit_enemies([enemy], game_state)
+      result = Hitbox.get_hit_enemies([enemy], player, game_state)
       assert result == []
     end
 
     test "laser hitbox is a proper rectangle (not a trapezoid)" do
       # Regression: previously the bottom-left vertex used {w, y+h}
       # instead of {x, y+h}, creating a trapezoid
+      player = %{
+        sprite: %{size: {50, 50}},
+        position: {400.0, 300.0, 50.0, 50.0},
+        hitbox: nil
+      }
+
       game_state = %{
         game_width: 800,
-        game_height: 600,
-        player: %{
-          sprite: %{size: {50, 50}},
-          position: {400.0, 300.0, 50.0, 50.0}
-        }
+        game_height: 600
       }
 
       # Enemy behind the player (x=5%) should NOT be hit by a laser
@@ -124,32 +141,37 @@ defmodule Flappy.HitboxTest do
       # the trapezoid stretched back to x=100px and could false-positive.
       enemy = %{
         position: {40.0, 300.0, 5.0, 50.0},
-        sprite: %{size: {100, 100}, name: :angular}
+        sprite: %{size: {100, 100}, name: :angular},
+        hitbox: nil
       }
 
-      result = Hitbox.get_hit_enemies([enemy], game_state)
+      result = Hitbox.get_hit_enemies([enemy], player, game_state)
       assert result == [], "laser should not hit enemies behind the player"
     end
   end
 
-  describe "check_for_enemy_collisions?/1" do
+  describe "check_for_enemy_collisions/3" do
     test "detects player collision with enemy" do
-      state = %{
-        game_width: 800,
-        game_height: 600,
-        player: %{
-          sprite: %{size: {50, 50}},
-          position: {0, 0, 100, 100}
-        },
-        enemies: [
-          %{
-            position: {0, 0, 100, 100},
-            sprite: %{size: {50, 50}, name: :angular}
-          }
-        ]
+      player = %{
+        sprite: %{size: {50, 50}},
+        position: {0, 0, 100, 100},
+        hitbox: nil
       }
 
-      result = Hitbox.check_for_enemy_collisions?(state)
+      enemies = [
+        %{
+          position: {0, 0, 100, 100},
+          sprite: %{size: {50, 50}, name: :angular},
+          hitbox: nil
+        }
+      ]
+
+      state = %{
+        game_width: 800,
+        game_height: 600
+      }
+
+      result = Hitbox.check_for_enemy_collisions(player, enemies, state)
       assert length(result) > 0
     end
   end

--- a/test/flappy/multiplayer_test.exs
+++ b/test/flappy/multiplayer_test.exs
@@ -1,0 +1,456 @@
+defmodule Flappy.MultiplayerTest do
+  use ExUnit.Case, async: true
+
+  alias Flappy.GameState
+
+  @player_a "player-a"
+  @player_b "player-b"
+
+  defp base_multiplayer_state do
+    state = %GameState{
+      game_id: "test-mp",
+      game_height: 600,
+      game_width: 800,
+      zoom_level: 1,
+      gravity: 175,
+      game_tick_interval: 15,
+      score_tick_interval: 1000,
+      score_multiplier: 10,
+      difficulty_score: 400,
+      game_over: false,
+      players: %{},
+      enemies: [],
+      power_ups: [],
+      explosions: [],
+      deaths_this_tick: []
+    }
+
+    state
+    |> GameState.add_player(@player_a, "Alice")
+    |> GameState.add_player(@player_b, "Bob")
+  end
+
+  describe "add_player/3" do
+    test "adds a player to the players map" do
+      state = %GameState{
+        game_id: "test",
+        game_height: 600,
+        game_width: 800,
+        players: %{},
+        deaths_this_tick: []
+      }
+
+      state = GameState.add_player(state, "p1", "Alice")
+
+      assert map_size(state.players) == 1
+      assert state.players["p1"].name == "Alice"
+      assert state.players["p1"].alive == true
+      assert state.players["p1"].survival_time == 0
+    end
+  end
+
+  describe "remove_player/2" do
+    test "removes a player and creates explosion if alive" do
+      state = base_multiplayer_state()
+
+      state = GameState.remove_player(state, @player_a)
+
+      assert map_size(state.players) == 1
+      refute Map.has_key?(state.players, @player_a)
+      assert length(state.explosions) == 1
+    end
+
+    test "removes a dead player without creating explosion" do
+      state = base_multiplayer_state()
+      player = %{state.players[@player_a] | alive: false}
+      state = %{state | players: Map.put(state.players, @player_a, player)}
+
+      state = GameState.remove_player(state, @player_a)
+
+      assert map_size(state.players) == 1
+      assert state.explosions == []
+    end
+  end
+
+  describe "multi-player tick" do
+    test "both players move independently" do
+      state = base_multiplayer_state()
+      {:ok, new_state} = GameState.tick(state)
+
+      a = new_state.players[@player_a]
+      b = new_state.players[@player_b]
+
+      # Both should have been affected by gravity
+      {_, ya_vel} = a.velocity
+      {_, yb_vel} = b.velocity
+      assert ya_vel > 0
+      assert yb_vel > 0
+    end
+
+    test "dead player is not updated" do
+      state = base_multiplayer_state()
+      player_a = %{state.players[@player_a] | alive: false, velocity: {0.0, 0.0}}
+      state = %{state | players: Map.put(state.players, @player_a, player_a)}
+
+      {:ok, new_state} = GameState.tick(state)
+
+      # Dead player velocity should be unchanged
+      assert new_state.players[@player_a].velocity == {0.0, 0.0}
+      # Alive player should have been updated
+      {_, yb_vel} = new_state.players[@player_b].velocity
+      assert yb_vel > 0
+    end
+  end
+
+  describe "per-player collision" do
+    test "player A dies from collision, player B unaffected" do
+      state = base_multiplayer_state()
+
+      # Place an enemy on top of player A
+      {px, py, pxp, pyp} = state.players[@player_a].position
+
+      enemy = %Flappy.Enemy{
+        position: {px, py, pxp, pyp},
+        velocity: {-75.0, 0},
+        sprite: %{image: "/images/angular_final.svg", size: {50, 50}, name: :angular},
+        id: "enemy-1"
+      }
+
+      state = %{state | enemies: [enemy]}
+
+      {:ok, new_state} = GameState.tick(state)
+
+      # Player A should be dead
+      refute new_state.players[@player_a].alive
+      # Player B should be alive
+      assert new_state.players[@player_b].alive
+      # Game should NOT be over (one player still alive)
+      assert new_state.game_over == false
+      # Player A should be in deaths_this_tick
+      assert @player_a in new_state.deaths_this_tick
+    end
+
+    test "game over when both players die" do
+      state = base_multiplayer_state()
+
+      # Place players at different positions, each with their own enemy
+      pos_a = {100.0, 300.0, 12.5, 50.0}
+      pos_b = {400.0, 200.0, 50.0, 33.3}
+      player_a = %{state.players[@player_a] | position: pos_a}
+      player_b = %{state.players[@player_b] | position: pos_b}
+      state = %{state | players: %{@player_a => player_a, @player_b => player_b}}
+
+      enemy_a = %Flappy.Enemy{
+        position: pos_a,
+        velocity: {-75.0, 0},
+        sprite: %{image: "/images/angular_final.svg", size: {50, 50}, name: :angular},
+        id: "enemy-a"
+      }
+
+      enemy_b = %Flappy.Enemy{
+        position: pos_b,
+        velocity: {-75.0, 0},
+        sprite: %{image: "/images/angular_final.svg", size: {50, 50}, name: :angular},
+        id: "enemy-b"
+      }
+
+      state = %{state | enemies: [enemy_a, enemy_b]}
+
+      assert {:game_over, new_state} = GameState.tick(state)
+      assert new_state.game_over == true
+    end
+  end
+
+  describe "power-up collection" do
+    test "first player to touch power-up gets it" do
+      state = base_multiplayer_state()
+
+      # Place both players at same position near a power-up
+      pos = {100.0, 300.0, 12.5, 50.0}
+      player_a = %{state.players[@player_a] | position: pos}
+      player_b = %{state.players[@player_b] | position: pos}
+      state = %{state | players: %{@player_a => player_a, @player_b => player_b}}
+
+      power_up = %Flappy.PowerUp{
+        position: {100.0, 300.0, 12.5, 50.0},
+        velocity: {0, 100},
+        sprite: %{image: "/images/react.svg", size: {50, 50}, name: :invincibility, chance: 50, duration: 10},
+        id: "pu-1"
+      }
+
+      state = %{state | power_ups: [power_up]}
+
+      {:ok, new_state} = GameState.tick(state)
+
+      # Power-up should be gone
+      refute Enum.any?(new_state.power_ups, &(&1.id == "pu-1"))
+
+      # Exactly one player should have gained invincibility
+      a_inv = new_state.players[@player_a].invincibility
+      b_inv = new_state.players[@player_b].invincibility
+
+      assert (a_inv and not b_inv) or (not a_inv and b_inv),
+             "exactly one player should get the power-up"
+    end
+  end
+
+  describe "shared enemy kills" do
+    test "laser kill removes enemy for everyone" do
+      state = base_multiplayer_state()
+
+      # Give player A a laser
+      player_a = %{
+        state.players[@player_a]
+        | laser_beam: true,
+          laser_duration: 3,
+          laser_allowed: true,
+          invincibility: true,
+          granted_powers: [{:invincibility, 5}]
+      }
+
+      state = %{state | players: Map.put(state.players, @player_a, player_a)}
+
+      {_px, py, _pxp, pyp} = player_a.position
+
+      enemy = %Flappy.Enemy{
+        position: {500.0, py, 62.5, pyp},
+        velocity: {-75.0, 0},
+        sprite: %{image: "/images/angular_final.svg", size: {100, 100}, name: :angular},
+        id: "enemy-laser"
+      }
+
+      state = %{state | enemies: [enemy]}
+
+      {:ok, new_state} = GameState.tick(state)
+
+      # Enemy destroyed by player A's laser - gone for everyone
+      refute Enum.any?(new_state.enemies, &(&1.id == "enemy-laser"))
+      # Score goes to player A
+      assert new_state.players[@player_a].score > 0
+    end
+  end
+
+  describe "crown computation" do
+    test "crown belongs to longest-surviving player" do
+      state = base_multiplayer_state()
+
+      # Give player A more survival time
+      player_a = %{state.players[@player_a] | survival_time: 10}
+      player_b = %{state.players[@player_b] | survival_time: 5}
+      state = %{state | players: %{@player_a => player_a, @player_b => player_b}}
+
+      assert GameState.crown_holder(state) == @player_a
+    end
+
+    test "crown transfers when holder dies" do
+      state = base_multiplayer_state()
+
+      player_a = %{state.players[@player_a] | survival_time: 10, alive: false}
+      player_b = %{state.players[@player_b] | survival_time: 5}
+      state = %{state | players: %{@player_a => player_a, @player_b => player_b}}
+
+      assert GameState.crown_holder(state) == @player_b
+    end
+
+    test "crown is nil when no players alive" do
+      state = base_multiplayer_state()
+
+      player_a = %{state.players[@player_a] | alive: false}
+      player_b = %{state.players[@player_b] | alive: false}
+      state = %{state | players: %{@player_a => player_a, @player_b => player_b}}
+
+      assert GameState.crown_holder(state) == nil
+    end
+  end
+
+  describe "last bird standing" do
+    test "detected when one player alive and at least one dead" do
+      state = base_multiplayer_state()
+
+      player_a = %{state.players[@player_a] | alive: false}
+      state = %{state | players: Map.put(state.players, @player_a, player_a)}
+
+      assert GameState.last_bird_standing?(state)
+    end
+
+    test "not triggered with only one player total" do
+      state = base_multiplayer_state()
+      state = %{state | players: Map.delete(state.players, @player_b)}
+
+      refute GameState.last_bird_standing?(state)
+    end
+
+    test "not triggered when all alive" do
+      state = base_multiplayer_state()
+
+      refute GameState.last_bird_standing?(state)
+    end
+  end
+
+  describe "survival time" do
+    test "increments each score tick for alive players" do
+      state = base_multiplayer_state()
+
+      new_state = GameState.score_tick(state)
+
+      assert new_state.players[@player_a].survival_time == 1
+      assert new_state.players[@player_b].survival_time == 1
+    end
+
+    test "does not increment for dead players" do
+      state = base_multiplayer_state()
+
+      player_a = %{state.players[@player_a] | alive: false, survival_time: 5}
+      state = %{state | players: Map.put(state.players, @player_a, player_a)}
+
+      new_state = GameState.score_tick(state)
+
+      assert new_state.players[@player_a].survival_time == 5
+      assert new_state.players[@player_b].survival_time == 1
+    end
+  end
+
+  describe "input routing" do
+    test "handle_input only affects specified player" do
+      state = base_multiplayer_state()
+
+      new_state = GameState.handle_input(state, @player_a, :go_up)
+
+      {_, a_vy} = new_state.players[@player_a].velocity
+      {_, b_vy} = new_state.players[@player_b].velocity
+
+      assert a_vy < 0, "player A should have upward velocity"
+      assert b_vy == 0.0, "player B should be unaffected"
+    end
+
+    test "input to dead player is ignored" do
+      state = base_multiplayer_state()
+      player_a = %{state.players[@player_a] | alive: false}
+      state = %{state | players: Map.put(state.players, @player_a, player_a)}
+
+      new_state = GameState.handle_input(state, @player_a, :go_up)
+
+      assert new_state.players[@player_a].velocity == {0.0, 0.0}
+    end
+  end
+
+  describe "no player-player collisions" do
+    test "overlapping players don't affect each other" do
+      state = base_multiplayer_state()
+
+      # Place both players at exact same position
+      pos = {200.0, 200.0, 25.0, 33.3}
+      player_a = %{state.players[@player_a] | position: pos}
+      player_b = %{state.players[@player_b] | position: pos}
+      state = %{state | players: %{@player_a => player_a, @player_b => player_b}}
+
+      {:ok, new_state} = GameState.tick(state)
+
+      # Both should still be alive
+      assert new_state.players[@player_a].alive
+      assert new_state.players[@player_b].alive
+    end
+  end
+
+  describe "alive_count" do
+    test "counts alive players" do
+      state = base_multiplayer_state()
+      assert GameState.alive_count(state) == 2
+
+      player_a = %{state.players[@player_a] | alive: false}
+      state = %{state | players: Map.put(state.players, @player_a, player_a)}
+      assert GameState.alive_count(state) == 1
+    end
+  end
+
+  describe "server reset on empty" do
+    test "removing last player results in empty players map" do
+      state = base_multiplayer_state()
+
+      state =
+        state
+        |> GameState.remove_player(@player_a)
+        |> GameState.remove_player(@player_b)
+
+      assert map_size(state.players) == 0
+    end
+  end
+
+  describe "explosion positioning" do
+    test "explosion is centered on enemy when enemy is destroyed" do
+      # Use remove_hit_enemies directly to test centering logic in isolation
+      state = %{
+        game_width: 800,
+        game_height: 600,
+        score_multiplier: 10,
+        enemies: [],
+        explosions: [],
+        players: %{
+          "p1" => %{
+            score: 0,
+            alive: true
+          }
+        }
+      }
+
+      # ruby_rails is 397x142 — a wide enemy where centering matters
+      enemy = %Flappy.Enemy{
+        position: {300.0, 200.0, 37.5, 33.3},
+        velocity: {-75.0, 0},
+        sprite: %{image: "/images/ruby_rails.svg", size: {397, 142}, name: :ruby_rails},
+        id: "wide-enemy"
+      }
+
+      state = %{state | enemies: [enemy]}
+      new_state = Flappy.Enemy.remove_hit_enemies(state, [enemy], "p1")
+
+      assert length(new_state.explosions) == 1
+
+      [explosion] = new_state.explosions
+      {_, _, exp_x, exp_y} = explosion.position
+      {_, _, enemy_x, enemy_y} = enemy.position
+
+      # Explosion should be offset from enemy origin (centered on enemy)
+      # For ruby_rails: 397x142, explosion: 100x100
+      # x_offset = (397 - 100) / 2 / 800 * 100 = 18.5625
+      # y_offset = (142 - 100) / 2 / 600 * 100 = 3.5
+      assert exp_x > enemy_x, "explosion x should be offset right to center on wide enemy"
+      assert exp_y > enemy_y, "explosion y should be offset down to center on tall enemy"
+    end
+
+    test "explosion is at same position for square enemies" do
+      state = %{
+        game_width: 800,
+        game_height: 600,
+        score_multiplier: 10,
+        enemies: [],
+        explosions: [],
+        players: %{
+          "p1" => %{
+            score: 0,
+            alive: true
+          }
+        }
+      }
+
+      # angular is 100x100 — same as explosion size, so no offset needed
+      enemy = %Flappy.Enemy{
+        position: {300.0, 200.0, 37.5, 33.3},
+        velocity: {-75.0, 0},
+        sprite: %{image: "/images/angular_final.svg", size: {100, 100}, name: :angular},
+        id: "square-enemy"
+      }
+
+      state = %{state | enemies: [enemy]}
+      new_state = Flappy.Enemy.remove_hit_enemies(state, [enemy], "p1")
+
+      [explosion] = new_state.explosions
+      {_, _, exp_x, exp_y} = explosion.position
+      {_, _, enemy_x, enemy_y} = enemy.position
+
+      # For 100x100 enemy with 100x100 explosion, offset should be 0
+      assert_in_delta exp_x, enemy_x, 0.01
+      assert_in_delta exp_y, enemy_y, 0.01
+    end
+  end
+end

--- a/test/flappy/power_up_test.exs
+++ b/test/flappy/power_up_test.exs
@@ -3,6 +3,8 @@ defmodule Flappy.PowerUpTest do
 
   alias Flappy.PowerUp
 
+  @player_id "test-player"
+
   describe "derive_power_flags/1" do
     test "laser power returns laser_allowed true with laser sprite" do
       granted_powers = [{:laser, 5}]
@@ -59,7 +61,7 @@ defmodule Flappy.PowerUpTest do
     end
   end
 
-  describe "grant_power_ups/2 integration" do
+  describe "grant_power_ups/3 integration" do
     test "collecting bomb while laser is active doesn't reset laser" do
       bomb = %Flappy.PowerUp{
         position: {200.0, 300.0, 25.0, 50.0},
@@ -69,16 +71,22 @@ defmodule Flappy.PowerUpTest do
       }
 
       state = %{
-        player: %{
-          score: 10,
-          granted_powers: [{:laser, 5}],
-          laser_allowed: true,
-          invincibility: false,
-          sprite: Flappy.Players.get_sprite(:laser),
-          position: {100.0, 300.0, 12.5, 50.0},
-          velocity: {0, 0},
-          laser_beam: false,
-          laser_duration: 0
+        players: %{
+          @player_id => %{
+            score: 10,
+            granted_powers: [{:laser, 5}],
+            laser_allowed: true,
+            invincibility: false,
+            sprite: Flappy.Players.get_sprite(:laser),
+            position: {100.0, 300.0, 12.5, 50.0},
+            velocity: {0, 0},
+            laser_beam: false,
+            laser_duration: 0,
+            hitbox: nil,
+            alive: true,
+            name: "Test",
+            survival_time: 0
+          }
         },
         power_ups: [bomb],
         enemies: [
@@ -94,10 +102,11 @@ defmodule Flappy.PowerUpTest do
         score_multiplier: 10
       }
 
-      new_state = Flappy.PowerUp.grant_power_ups(state, [bomb])
+      new_state = Flappy.PowerUp.grant_power_ups(state, [bomb], @player_id)
 
-      assert new_state.player.laser_allowed == true, "laser should still be active after bomb"
-      assert new_state.player.sprite == Flappy.Players.get_sprite(:laser)
+      player = new_state.players[@player_id]
+      assert player.laser_allowed == true, "laser should still be active after bomb"
+      assert player.sprite == Flappy.Players.get_sprite(:laser)
     end
   end
 
@@ -114,16 +123,22 @@ defmodule Flappy.PowerUpTest do
         score_multiplier: 10,
         difficulty_score: 400,
         game_over: false,
-        player: %{
-          score: 0,
-          position: {100.0, 300.0, 12.5, 50.0},
-          velocity: {0.0, 0.0},
-          sprite: Flappy.Players.get_sprite(:laser),
-          granted_powers: [{:laser, 1}],
-          laser_allowed: true,
-          laser_beam: false,
-          laser_duration: 0,
-          invincibility: false
+        players: %{
+          @player_id => %{
+            score: 0,
+            position: {100.0, 300.0, 12.5, 50.0},
+            velocity: {0.0, 0.0},
+            sprite: Flappy.Players.get_sprite(:laser),
+            granted_powers: [{:laser, 1}],
+            laser_allowed: true,
+            laser_beam: false,
+            laser_duration: 0,
+            invincibility: false,
+            hitbox: nil,
+            alive: true,
+            name: "Test",
+            survival_time: 0
+          }
         },
         enemies: [],
         power_ups: [],
@@ -134,13 +149,14 @@ defmodule Flappy.PowerUpTest do
       # Player should lose laser_allowed and revert to default sprite
       new_state = Flappy.GameState.score_tick(state)
 
+      player = new_state.players[@player_id]
       # Duration 1->0 means it's still in the list but at 0
       # Next tick it'll be removed. But flags should update based on current state.
       # With duration 0, laser is effectively expired.
-      assert new_state.player.laser_allowed == false,
+      assert player.laser_allowed == false,
              "laser_allowed should be false when laser power expires"
 
-      assert new_state.player.sprite == Flappy.Players.get_sprite(),
+      assert player.sprite == Flappy.Players.get_sprite(),
              "sprite should revert to default when laser expires"
     end
   end


### PR DESCRIPTION
## Summary

- **Refactored GameState** from single `player` field to a `players` map (`%{player_id => player_state}`), unifying singleplayer and multiplayer logic — singleplayer is simply one entry in the map
- **Added drop-in/drop-out multiplayer** at `/multiplayer` with shared enemies, power-ups, and a global game world via a new supervised `MultiplayerEngine` GenServer
- **Added King of the Hill crown system** — crown belongs to the longest-surviving player and transfers on death
- **Added multiplayer UI** — golden highlight on own bird, name tags, crown indicator, 3-section HUD (score/time, crown holder, player count), LAST BIRD STANDING banner, death screen with rejoin
- **Added multiplayer leaderboard** — new `multiplayer_scores` table tracking survival times, with tabs on the high scores page
- **Fixed explosion positioning bug** — explosions now center on the enemy instead of appearing at the top-left corner
- **Updated all supporting modules** (Enemy, PowerUp, Hitbox, Position, Player) for per-player collision detection and the new players map structure

Closes #64

## Test plan

- [x] All 112 existing + new tests pass (`mix test`)
- [x] Compilation clean (no errors, only CRLF warnings on Windows)
- [x] Database migration runs cleanly
- [ ] Manual test: singleplayer at `/` works exactly as before
- [ ] Manual test: multiplayer join/leave/rejoin flow
- [ ] Manual test: crown transfers correctly on death
- [ ] Manual test: power-ups collected by first player only
- [ ] Manual test: disconnect causes instant death
- [ ] Manual test: high scores tabs show both leaderboards
- [ ] Manual test: explosions appear centered on enemies

🤖 Generated with [Claude Code](https://claude.com/claude-code)