### PR TITLE
Fix multiplayer ghost players, score saving, and distributed support

### DIFF
--- a/lib/flappy/multiplayer_engine.ex
+++ b/lib/flappy/multiplayer_engine.ex
@@ -45,16 +45,30 @@ defmodule Flappy.MultiplayerEngine do
 
   @impl true
   def init(:ok) do
+    Process.put(:pid_to_player, %{})
     {:ok, fresh_state()}
   end
 
   @impl true
-  def handle_call({:join, player_id, player_name}, _from, state) do
+  def handle_call({:join, player_id, player_name}, {caller_pid, _tag}, state) do
+    pid_map = Process.get(:pid_to_player, %{})
+
+    # Clean up any existing player for this LiveView process (handles rejoin)
+    state =
+      case Map.get(pid_map, caller_pid) do
+        nil -> state
+        old_player_id ->
+          Process.put(:pid_to_player, Map.delete(pid_map, caller_pid))
+          do_leave(state, old_player_id)
+      end
+
+    # Monitor the LiveView process for automatic cleanup on disconnect
+    Process.monitor(caller_pid)
+
     needs_fresh_start = map_size(state.players) == 0 || state.game_over
 
     state =
       if needs_fresh_start do
-        # First player or game_over: fresh state + start timers
         stop_timers(state)
         state = fresh_state()
         state = GameState.add_player(state, player_id, player_name)
@@ -63,6 +77,9 @@ defmodule Flappy.MultiplayerEngine do
       else
         GameState.add_player(state, player_id, player_name)
       end
+
+    # Track pid → player_id mapping
+    Process.put(:pid_to_player, Map.put(Process.get(:pid_to_player, %{}), caller_pid, player_id))
 
     {:reply, :ok, state}
   end
@@ -73,27 +90,12 @@ defmodule Flappy.MultiplayerEngine do
 
   @impl true
   def handle_cast({:leave, player_id}, state) do
-    player = state.players[player_id]
+    # Clean up pid → player mapping
+    pid_map = Process.get(:pid_to_player, %{})
+    pid_map = pid_map |> Enum.reject(fn {_pid, id} -> id == player_id end) |> Map.new()
+    Process.put(:pid_to_player, pid_map)
 
-    # Save survival time if player was alive
-    if player && Map.get(player, :alive, true) do
-      save_score(player, state)
-    end
-
-    state = GameState.remove_player(state, player_id)
-
-    broadcast(state)
-
-    # If no players left, stop timers and reset
-    state =
-      if map_size(state.players) == 0 do
-        stop_timers(state)
-        fresh_state()
-      else
-        state
-      end
-
-    {:noreply, state}
+    {:noreply, do_leave(state, player_id)}
   end
 
   def handle_cast({:input, player_id, action}, state) do
@@ -138,6 +140,19 @@ defmodule Flappy.MultiplayerEngine do
       {:noreply, state}
     else
       {:noreply, GameState.score_tick(state)}
+    end
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    pid_map = Process.get(:pid_to_player, %{})
+
+    case Map.pop(pid_map, pid) do
+      {nil, _} ->
+        {:noreply, state}
+
+      {player_id, new_pid_map} ->
+        Process.put(:pid_to_player, new_pid_map)
+        {:noreply, do_leave(state, player_id)}
     end
   end
 
@@ -195,15 +210,12 @@ defmodule Flappy.MultiplayerEngine do
     end)
   end
 
-  # On game_over, only save players NOT already in deaths_this_tick
-  # (those were already saved by handle_deaths in prior ticks)
+  # On game_over, save scores only for players who died in the final tick.
+  # Players who died in earlier ticks were already saved by handle_deaths.
   defp save_unsaved_scores(state) do
-    already_saved = MapSet.new(state.deaths_this_tick)
-
-    Enum.each(state.players, fn {player_id, player} ->
-      unless MapSet.member?(already_saved, player_id) do
-        save_score(player, state)
-      end
+    Enum.each(state.deaths_this_tick, fn player_id ->
+      player = state.players[player_id]
+      if player, do: save_score(player, state)
     end)
   end
 
@@ -215,6 +227,26 @@ defmodule Flappy.MultiplayerEngine do
         {:ok, _} -> :ok
         {:error, reason} -> Logger.error("Failed to save multiplayer score: #{inspect(reason)}")
       end
+    end
+  end
+
+  defp do_leave(state, player_id) do
+    player = state.players[player_id]
+
+    if player do
+      if Map.get(player, :alive, true), do: save_score(player, state)
+
+      state = GameState.remove_player(state, player_id)
+      broadcast(state)
+
+      if map_size(state.players) == 0 do
+        stop_timers(state)
+        fresh_state()
+      else
+        state
+      end
+    else
+      state
     end
   end
 end

--- a/lib/flappy/multiplayer_engine.ex
+++ b/lib/flappy/multiplayer_engine.ex
@@ -63,7 +63,9 @@ defmodule Flappy.MultiplayerEngine do
       end
 
     # Monitor the LiveView process for automatic cleanup on disconnect
-    Process.monitor(caller_pid)
+    unless Map.has_key?(Process.get(:pid_to_player, %{}), caller_pid) do
+      Process.monitor(caller_pid)
+    end
 
     needs_fresh_start = map_size(state.players) == 0 || state.game_over
 
@@ -117,14 +119,13 @@ defmodule Flappy.MultiplayerEngine do
     else
       case GameState.tick(state) do
         {:game_over, state} ->
-          # All players dead — save only those not already saved by handle_deaths
-          save_unsaved_scores(state)
+          save_deaths_this_tick(state)
           stop_timers(state)
           broadcast(state)
           {:noreply, state}
 
         {:ok, state} ->
-          handle_deaths(state)
+          save_deaths_this_tick(state)
           broadcast(state)
           {:noreply, state}
       end
@@ -202,17 +203,8 @@ defmodule Flappy.MultiplayerEngine do
     )
   end
 
-  # Save scores for players who just died this tick
-  defp handle_deaths(state) do
-    Enum.each(state.deaths_this_tick, fn player_id ->
-      player = state.players[player_id]
-      if player, do: save_score(player, state)
-    end)
-  end
-
-  # On game_over, save scores only for players who died in the final tick.
-  # Players who died in earlier ticks were already saved by handle_deaths.
-  defp save_unsaved_scores(state) do
+  # Save scores for players who died this tick (used for both mid-game deaths and game_over)
+  defp save_deaths_this_tick(state) do
     Enum.each(state.deaths_this_tick, fn player_id ->
       player = state.players[player_id]
       if player, do: save_score(player, state)

--- a/lib/flappy/multiplayer_engine.ex
+++ b/lib/flappy/multiplayer_engine.ex
@@ -15,28 +15,30 @@ defmodule Flappy.MultiplayerEngine do
 
   # --- Client API ---
 
+  @global_name {:global, __MODULE__}
+
   def start_link(_opts) do
-    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+    GenServer.start_link(__MODULE__, :ok, name: @global_name)
   end
 
   def join(player_id, player_name) do
-    GenServer.call(__MODULE__, {:join, player_id, player_name})
+    GenServer.call(@global_name, {:join, player_id, player_name})
   end
 
   def leave(player_id) do
-    GenServer.cast(__MODULE__, {:leave, player_id})
+    GenServer.cast(@global_name, {:leave, player_id})
   end
 
   def get_state do
-    GenServer.call(__MODULE__, :get_state)
+    GenServer.call(@global_name, :get_state)
   end
 
   def player_input(player_id, action) do
-    GenServer.cast(__MODULE__, {:input, player_id, action})
+    GenServer.cast(@global_name, {:input, player_id, action})
   end
 
   def update_viewport(zoom_level, game_width, game_height) do
-    GenServer.cast(__MODULE__, {:update_viewport, zoom_level, game_width, game_height})
+    GenServer.cast(@global_name, {:update_viewport, zoom_level, game_width, game_height})
   end
 
   def pubsub_topic, do: @pubsub_topic

--- a/lib/flappy/multiplayer_engine.ex
+++ b/lib/flappy/multiplayer_engine.ex
@@ -215,9 +215,13 @@ defmodule Flappy.MultiplayerEngine do
     survival_ms = Map.get(player, :survival_time, 0) * state.score_tick_interval
 
     if survival_ms > 0 do
-      case MultiplayerScores.save_score(player.name, survival_ms) do
-        {:ok, _} -> :ok
-        {:error, reason} -> Logger.error("Failed to save multiplayer score: #{inspect(reason)}")
+      try do
+        case MultiplayerScores.save_score(player.name, survival_ms) do
+          {:ok, _} -> :ok
+          {:error, reason} -> Logger.error("Failed to save multiplayer score: #{inspect(reason)}")
+        end
+      rescue
+        e -> Logger.error("Failed to save multiplayer score: #{Exception.message(e)}")
       end
     end
   end

--- a/lib/flappy_web/live/flappy_live.ex
+++ b/lib/flappy_web/live/flappy_live.ex
@@ -16,40 +16,64 @@ defmodule FlappyWeb.FlappyLive do
         :if={!@game_state.game_over && !@game_started}
         class="flex flex-col items-center justify-center h-screen"
       >
-        <p class="text-white text-4xl my-11">Get ready to play Flappy Phoenix!</p>
+        <p class="text-white text-5xl font-bold mb-8" style="text-shadow: 0 2px 10px rgba(0,0,0,0.5);">
+          Get ready to play Flappy Phoenix!
+        </p>
 
-        <div class="space-y-2">
-          <p class="text-white text-2xl text-center">Don't let the 🐦‍🔥 fly off of the screen!</p>
-
-          <p class="text-white text-2xl text-center">
-            Use WASD or the arrow keys (⬆️ ⬇️ ⬅️ and ➡️ ) to move up, down, left and right!
-          </p>
-
-          <p class="text-white text-2xl text-center">
-            There are currently three power-ups, which fall from above, which make you stronger:
-            <ul class="flex flex-col pt-4 items-center justify-center">
-              <div class="flex flex-row">
-                <img src="/images/react.svg" class="w-7 h-7" />
-                <li>
-                  <p class="text-white text-2xl text-center">REACT-ive armour</p>
-                </li>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-3xl w-full px-4 mb-8">
+          <%!-- Controls card --%>
+          <div class="bg-black bg-opacity-60 backdrop-blur-sm rounded-xl p-5 border border-white border-opacity-10">
+            <p class="text-yellow-300 font-bold text-lg mb-3">Controls</p>
+            <p class="text-gray-200 text-sm leading-relaxed">
+              Use <span class="font-mono bg-white bg-opacity-15 px-1.5 py-0.5 rounded">WASD</span>
+              or <span class="font-mono bg-white bg-opacity-15 px-1.5 py-0.5 rounded">Arrow Keys</span>
+              to fly around.
+            </p>
+            <p class="text-gray-200 text-sm leading-relaxed mt-2">
+              Don't fly off the screen!
+            </p>
+            <div class="flex justify-center mt-3">
+              <div class="relative">
+                <div class="absolute inset-0 rounded-full bg-yellow-400 blur-lg opacity-40 scale-125"></div>
+                <img src="/images/flipped_phoenix.svg" class="relative w-16 h-auto drop-shadow-[0_0_8px_rgba(250,204,21,0.6)]" />
               </div>
+              <p class="text-yellow-300 text-xs italic mt-1 ml-1 self-end">(the golden one is you!)</p>
+            </div>
+          </div>
 
-              <div class="flex flex-row">
-                <img src="/images/laser.svg" class="w-7 h-7" />
-                <li>
-                  <p class="text-white text-2xl text-center">The ELIXIR of LASER - Space to FIRE!</p>
-                </li>
-              </div>
-
-              <div class="flex flex-row">
-                <img src="/images/bomb.svg" class="w-7 h-7" />
-                <li>
-                  <p class="text-white text-2xl text-center">THE OBANomb</p>
-                </li>
-              </div>
+          <%!-- Power-ups card --%>
+          <div class="bg-black bg-opacity-60 backdrop-blur-sm rounded-xl p-5 border border-white border-opacity-10">
+            <p class="text-yellow-300 font-bold text-lg mb-3">Power-ups</p>
+            <ul class="space-y-2">
+              <li class="flex items-center gap-2">
+                <img src="/images/react.svg" class="w-6 h-6 flex-shrink-0" />
+                <span class="text-gray-200 text-sm">REACT-ive armour</span>
+              </li>
+              <li class="flex items-center gap-2">
+                <img src="/images/laser.svg" class="w-6 h-6 flex-shrink-0" />
+                <span class="text-gray-200 text-sm">ELIXIR of LASER
+                  <span class="font-mono bg-white bg-opacity-15 px-1.5 py-0.5 rounded text-xs">Space</span>
+                </span>
+              </li>
+              <li class="flex items-center gap-2">
+                <img src="/images/bomb.svg" class="w-6 h-6 flex-shrink-0" />
+                <span class="text-gray-200 text-sm">THE OBANomb</span>
+              </li>
             </ul>
-          </p>
+          </div>
+
+          <%!-- Enemies card --%>
+          <div class="bg-black bg-opacity-60 backdrop-blur-sm rounded-xl p-5 border border-white border-opacity-10">
+            <p class="text-yellow-300 font-bold text-lg mb-3">Watch out!</p>
+            <p class="text-gray-200 text-sm leading-relaxed">
+              Other frameworks are coming for you. Don't let them touch you!
+            </p>
+            <div class="flex gap-3 mt-3 justify-center">
+              <img src="/images/angular_final.svg" class="w-8 h-8 opacity-70" />
+              <img src="/images/node.svg" class="w-8 h-8 opacity-70" />
+              <img src="/images/ruby_rails.svg" class="h-8 opacity-70" />
+            </div>
+          </div>
         </div>
 
         <.simple_form for={@name_form} phx-submit="enter_name" class="flex flex-col items-center">
@@ -75,10 +99,6 @@ defmodule FlappyWeb.FlappyLive do
             </.button>
           </div>
         </.simple_form>
-
-        <p class="text-white text-2xl text-center">
-          Oh, and don't let those other frameworks touch you!
-        </p>
       </div>
       <%!-- Score container --%>
       <div :if={@game_state.game_over} class="flex flex-col items-center justify-center h-screen z-50">

--- a/lib/flappy_web/live/flappy_multiplayer_live.ex
+++ b/lib/flappy_web/live/flappy_multiplayer_live.ex
@@ -56,6 +56,7 @@ defmodule FlappyWeb.FlappyMultiplayerLive do
           Survival time: {format_survival_time(@my_survival_time)}
         </p>
         <p class="text-white text-xl mb-6">Score: {@my_score}</p>
+        <p :if={@game_over} class="text-yellow-300 text-xl mb-2">Game Over — All birds down!</p>
 
         <.button phx-click="rejoin" class="bg-purple-600 text-white px-6 py-3 rounded text-2xl">
           Rejoin
@@ -202,6 +203,7 @@ defmodule FlappyWeb.FlappyMultiplayerLive do
      |> assign(:name_form, to_form(%{}))
      |> assign(:joined, false)
      |> assign(:dead, false)
+     |> assign(:game_over, false)
      |> assign(:player_id, nil)
      |> assign(:player_name, "")
      |> assign(:game_state, %GameState{})
@@ -295,6 +297,7 @@ defmodule FlappyWeb.FlappyMultiplayerLive do
     socket =
       socket
       |> assign(:game_state, game_state)
+      |> assign(:game_over, game_state.game_over)
       |> assign(:my_score, if(my_player, do: my_player.score, else: assigns.my_score))
       |> assign(:my_survival_time, if(my_player, do: Map.get(my_player, :survival_time, 0), else: assigns.my_survival_time))
       |> assign(:crown_holder_id, crown_id)
@@ -380,6 +383,7 @@ defmodule FlappyWeb.FlappyMultiplayerLive do
     socket
     |> assign(:joined, true)
     |> assign(:dead, false)
+    |> assign(:game_over, false)
     |> assign(:player_id, player_id)
     |> assign(:player_name, player_name)
     |> assign(:last_bird_standing, false)

--- a/test/flappy/multiplayer_engine_test.exs
+++ b/test/flappy/multiplayer_engine_test.exs
@@ -1,0 +1,188 @@
+defmodule Flappy.MultiplayerEngineTest do
+  use ExUnit.Case, async: false
+
+  alias Flappy.MultiplayerEngine
+
+  setup do
+    # Ensure clean engine state before each test
+    state = MultiplayerEngine.get_state()
+
+    for {player_id, _} <- state.players do
+      MultiplayerEngine.leave(player_id)
+    end
+
+    # Give the async casts time to process
+    Process.sleep(50)
+    :ok
+  end
+
+  describe "rejoin cleanup" do
+    test "joining again from same process removes old player" do
+      :ok = MultiplayerEngine.join("player-old", "Alice")
+      state = MultiplayerEngine.get_state()
+      assert Map.has_key?(state.players, "player-old")
+
+      # Rejoin from the same process (simulates clicking Rejoin)
+      :ok = MultiplayerEngine.join("player-new", "Alice")
+      state = MultiplayerEngine.get_state()
+
+      refute Map.has_key?(state.players, "player-old"),
+        "old player should be cleaned up on rejoin"
+
+      assert Map.has_key?(state.players, "player-new")
+      assert map_size(state.players) == 1
+
+      MultiplayerEngine.leave("player-new")
+    end
+
+    test "ghost players don't accumulate across multiple rejoins" do
+      :ok = MultiplayerEngine.join("id-1", "Alice")
+      :ok = MultiplayerEngine.join("id-2", "Alice")
+      :ok = MultiplayerEngine.join("id-3", "Alice")
+
+      state = MultiplayerEngine.get_state()
+
+      assert map_size(state.players) == 1, "should only have latest player, no ghosts"
+      assert Map.has_key?(state.players, "id-3")
+      refute Map.has_key?(state.players, "id-1")
+      refute Map.has_key?(state.players, "id-2")
+
+      MultiplayerEngine.leave("id-3")
+    end
+
+    test "leaving an already-cleaned-up player is a no-op" do
+      :ok = MultiplayerEngine.join("will-rejoin", "Alice")
+      :ok = MultiplayerEngine.join("after-rejoin", "Alice")
+
+      # Old player was already cleaned up by rejoin. Leave it again — should be harmless.
+      MultiplayerEngine.leave("will-rejoin")
+      Process.sleep(50)
+
+      state = MultiplayerEngine.get_state()
+      assert Map.has_key?(state.players, "after-rejoin"),
+        "new player should still exist after stale leave"
+
+      MultiplayerEngine.leave("after-rejoin")
+    end
+  end
+
+  describe "process monitoring" do
+    test "player is removed when their process dies" do
+      test_pid = self()
+
+      {pid, ref} =
+        spawn_monitor(fn ->
+          :ok = MultiplayerEngine.join("monitored-player", "Bob")
+          send(test_pid, :joined)
+          receive do: (:stop -> :ok)
+        end)
+
+      assert_receive :joined, 1000
+
+      state = MultiplayerEngine.get_state()
+      assert Map.has_key?(state.players, "monitored-player")
+
+      # Kill the process (simulates tab close / browser crash)
+      Process.exit(pid, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :killed}
+      Process.sleep(50)
+
+      state = MultiplayerEngine.get_state()
+
+      refute Map.has_key?(state.players, "monitored-player"),
+        "player should be auto-removed when process dies"
+    end
+
+    test "killing one process doesn't affect another player" do
+      test_pid = self()
+
+      {pid_a, ref_a} =
+        spawn_monitor(fn ->
+          :ok = MultiplayerEngine.join("proc-a", "Alice")
+          send(test_pid, {:joined, :a})
+          receive do: (:stop -> :ok)
+        end)
+
+      {pid_b, ref_b} =
+        spawn_monitor(fn ->
+          :ok = MultiplayerEngine.join("proc-b", "Bob")
+          send(test_pid, {:joined, :b})
+          receive do: (:stop -> :ok)
+        end)
+
+      assert_receive {:joined, :a}, 1000
+      assert_receive {:joined, :b}, 1000
+
+      state = MultiplayerEngine.get_state()
+      assert map_size(state.players) == 2
+
+      # Kill only process A
+      Process.exit(pid_a, :kill)
+      assert_receive {:DOWN, ^ref_a, :process, ^pid_a, :killed}
+      Process.sleep(50)
+
+      state = MultiplayerEngine.get_state()
+      refute Map.has_key?(state.players, "proc-a")
+      assert Map.has_key?(state.players, "proc-b"), "proc-b should still exist"
+
+      # Cleanup
+      Process.exit(pid_b, :kill)
+      assert_receive {:DOWN, ^ref_b, :process, ^pid_b, :killed}
+    end
+  end
+
+  describe "leave" do
+    test "leave removes player from state" do
+      :ok = MultiplayerEngine.join("leave-test", "Alice")
+      state = MultiplayerEngine.get_state()
+      assert Map.has_key?(state.players, "leave-test")
+
+      MultiplayerEngine.leave("leave-test")
+      Process.sleep(50)
+
+      state = MultiplayerEngine.get_state()
+      refute Map.has_key?(state.players, "leave-test")
+    end
+
+    test "leave for nonexistent player is a no-op" do
+      MultiplayerEngine.leave("nonexistent")
+      Process.sleep(50)
+
+      # Engine should still be functional
+      state = MultiplayerEngine.get_state()
+      assert is_map(state.players)
+    end
+  end
+
+  describe "fresh start" do
+    test "joining after all players leave creates fresh state" do
+      test_pid = self()
+
+      {pid, ref} =
+        spawn_monitor(fn ->
+          :ok = MultiplayerEngine.join("temp-player", "Alice")
+          send(test_pid, :joined)
+          receive do: (:stop -> :ok)
+        end)
+
+      assert_receive :joined, 1000
+
+      Process.exit(pid, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :killed}
+      Process.sleep(50)
+
+      state = MultiplayerEngine.get_state()
+      assert map_size(state.players) == 0
+
+      # Join again — should get fresh state
+      :ok = MultiplayerEngine.join("fresh-player", "Charlie")
+      state = MultiplayerEngine.get_state()
+
+      assert map_size(state.players) == 1
+      assert Map.has_key?(state.players, "fresh-player")
+      assert state.game_over == false
+
+      MultiplayerEngine.leave("fresh-player")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- **Ghost players fix**: Process monitoring via `Process.monitor` catches tab closes immediately, and rejoin cleanup removes old player_id before creating a new one — no more phantom duplicates
- **Score saving fixes**: Deduplicated save logic (only save on death tick, not again on game_over) and wrapped `save_score` in try/rescue so DB exceptions don't crash the shared MultiplayerEngine GenServer
- **Distributed cluster support**: Switched MultiplayerEngine from local `name: __MODULE__` to `{:global, __MODULE__}` so only one engine instance runs across a multi-node cluster — players on different machines now join the same game
- **UI refresh**: Redesigned singleplayer start screen into 3 responsive glassmorphism cards (Controls, Power-ups, Watch Out)

## Test plan
- [x] All 120 tests pass
- [ ] Verify multiplayer works on single-node deploy (rejoin, death, score saving)
- [ ] Verify players on different nodes in a cluster can see each other
- [ ] Confirm singleplayer start screen renders correctly on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)